### PR TITLE
Support for locking the touch screen without blanking the display

### DIFF
--- a/mce.h
+++ b/mce.h
@@ -213,7 +213,9 @@ typedef enum {
 	/** Enable proximity lock (no UI); write only */
 	LOCK_ON_PROXIMITY = 5,
 	/** Toggle lock state; write only */
-	LOCK_TOGGLE = 6
+	LOCK_TOGGLE = 6,
+	/** Delayed lock; write only */
+	LOCK_ON_DELAYED = 7
 } lock_state_t;
 
 /** Battery status */

--- a/tklock.c
+++ b/tklock.c
@@ -1722,6 +1722,7 @@ static void set_tklock_state(lock_state_t lock_state)
 	case LOCK_ON:
 	case LOCK_ON_DIMMED:
 	case LOCK_ON_PROXIMITY:
+	case LOCK_ON_DELAYED:
 		if (((submode & MCE_BOOTUP_SUBMODE) != 0) &&
 		    (is_malf_state_enabled() == FALSE) &&
 		    ((lock_state != LOCK_ON_PROXIMITY) ||
@@ -1782,6 +1783,14 @@ static void set_tklock_state(lock_state_t lock_state)
 
 		if (saved_tklock_state == MCE_TKLOCK_VISUAL_STATE)
 			setup_tklock_visual_blank_timeout();
+		break;
+
+	case LOCK_ON_DELAYED:
+		synthesise_inactivity();
+		enable_tklock();
+
+		saved_tklock_state = MCE_TKLOCK_LOCKED_STATE;
+		setup_tklock_visual_blank_timeout();
 		break;
 
 	case LOCK_TOGGLE:
@@ -1931,6 +1940,8 @@ static gboolean tklock_mode_change_req_dbus_cb(DBusMessage *const msg)
 		set_tklock_state(LOCK_ON);
 	} else if (!strcmp(MCE_TK_LOCKED_DIM, mode)) {
 		set_tklock_state(LOCK_ON_DIMMED);
+	} else if (!strcmp(MCE_TK_LOCKED_DELAY, mode)) {
+		set_tklock_state(LOCK_ON_DELAYED);
 	} else if (!strcmp(MCE_TK_UNLOCKED, mode)) {
 		set_tklock_state(LOCK_OFF);
 

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -221,6 +221,7 @@ static void usage(void)
 		  "                                    valid modes are:\n"
 		  "                                    ``locked'', "
 		  "``locked-dim'',\n"
+		  "                                    ``locked-delay'',\n"
 		  "                                    and ``unlocked''\n"
 		  "      --enable-led                enable LED framework\n"
 		  "      --disable-led               disable LED framework\n"
@@ -852,7 +853,7 @@ static void mcetool_dbus_exit(void)
  * Enable/disable the tklock
  *
  * @param mode The mode to change to; valid modes:
- *             "locked", "locked-dim", "unlocked"
+ *             "locked", "locked-dim", "locked-delay", "unlocked"
  * @return TRUE on success, FALSE on FAILURE
  */
 static gboolean set_tklock_mode(gchar **mode)


### PR DESCRIPTION
Adds a possibility to request screen locking without instantly blanking the display.

Requires the following addition to /usr/include/mce/mode-names.h from https://github.com/nemomobile/mce-dev/pull/1 :
/**
- Touchscreen/Keypad locked with delay
- 
- @since v1.12.2
  */
  #define MCE_TK_LOCKED_DELAY                     "locked-delay"

Can be tested with

dbus-send --system --type=method_call --print-reply --dest=com.nokia.mce /com/nokia/mce/request com.nokia.mce.request.req_tklock_mode_change string:locked-delay
