### PR TITLE
Iofixes

### DIFF
--- a/mce-io.c
+++ b/mce-io.c
@@ -799,7 +799,7 @@ static gboolean io_chunk_cb(GIOChannel *source,
 	if( iomon->chunk_size < bytes_want ) {
 		bytes_want -= bytes_want % iomon->chunk_size;
 	} else {
-		bytes_want -= iomon->chunk_size;
+		bytes_want = iomon->chunk_size;
 	}
 
 	buffer = g_malloc(bytes_want);


### PR DESCRIPTION
MCE (and glib) incorrectly assume that lseek() works with various device files. While seeking in
/dev/input/eventX files has never been possible, older kernels (for example 2.6.32) do not report lseek() errors. By lucky chance the fact that mce is using buffered reads hides most of the problems this might cause.

However, if kernel is recent enough to return ESPIPE when seek in evdev file is attempted, the touchscreen event skipping logic in mce starts to misbehave.

Also using buffered reads might cause broken wakelock chains when recovering from suspend due to power key press.

Signed-off-by: Simo Piiroinen simo.piiroinen@jollamobile.com
