### PR TITLE
Make MCE talk to Lipstick instead of System UI

### DIFF
--- a/systemui/dbus-names.h
+++ b/systemui/dbus-names.h
@@ -20,24 +20,10 @@
 #define _SYSTEMUI_DBUS_NAMES_H
 
 /** The System UI service */
-#define SYSTEMUI_SERVICE       "com.nokia.system_ui"
+#define SYSTEMUI_SERVICE       "org.nemomobile.lipstick"
 /** The System UI request interface. */
-#define SYSTEMUI_REQUEST_IF    "com.nokia.system_ui.request"
-/** The System UI signal interface. */
-#define SYSTEMUI_SIGNAL_IF     "com.nokia.system_ui.signal"
+#define SYSTEMUI_REQUEST_IF    "org.nemomobile.lipstick.screenlock"
 /** The System UI request path. */
-#define SYSTEMUI_REQUEST_PATH  "/com/nokia/system_ui/request"
-/** The System UI signal path. */
-#define SYSTEMUI_SIGNAL_PATH   "/com/nokia/system_ui/signal"
-
-/**
- * Requests system UI to shut down.
- */
-#define SYSTEMUI_QUIT_REQ      "quit"
-
-/**
- * Notify everyone that the System UI has started.
- */
-#define SYSTEMUI_STARTED_SIG   "system_ui_started"
+#define SYSTEMUI_REQUEST_PATH  "/screenlock"
 
 #endif /* _SYSTEMUI_DBUS_NAMES_H */

--- a/tklock.c
+++ b/tklock.c
@@ -1163,7 +1163,7 @@ static gboolean open_tklock_ui(dbus_uint32_t mode)
 		goto EXIT;
 	}
 
-	/* com.nokia.system_ui.request.tklock_open */
+	/* org.nemomobile.lipstick.screenlock.tklock_open */
 	status = dbus_send(SYSTEMUI_SERVICE, SYSTEMUI_REQUEST_PATH,
 			   SYSTEMUI_REQUEST_IF, SYSTEMUI_TKLOCK_OPEN_REQ,
 			   tklock_reply_dbus_cb,
@@ -1199,7 +1199,7 @@ static gboolean close_tklock_ui(void)
 	gboolean silent = TRUE;
 	gboolean status = FALSE;
 
-	/* com.nokia.system_ui.request.tklock_close */
+	/* org.nemomobile.lipstick.screenlock.tklock_close */
 	status = dbus_send(SYSTEMUI_SERVICE, SYSTEMUI_REQUEST_PATH,
 			   SYSTEMUI_REQUEST_IF, SYSTEMUI_TKLOCK_CLOSE_REQ,
 			   NULL,


### PR DESCRIPTION
Also removes unused defines.

Lipstick side patch:

https://github.com/nemomobile/lipstick/pull/30
