### PR TITLE
Enable MCE wakelock manipulation code by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 PKG_CONFIG   ?= pkg-config
 
 # Whether to enable wakelock compatibility code
-ENABLE_WAKELOCKS ?= n
+ENABLE_WAKELOCKS ?= y
 
 # Whether to enable sysinfod queries
 ENABLE_SYSINFOD_QUERIES ?= n


### PR DESCRIPTION
The logic is by design such that wakelock calls turn into NOPs
if wakelock related sysfs files are not present at mce startup,
so we might as well turn the default to enabled.
