### PR TITLE
Attach processing order prefix to mce ini-files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,9 @@ TOOLS   += $(TOOLDIR)/mcetool
 TESTS   += $(TESTSDIR)/mcetorture
 
 # MCE configuration files
-CONFFILE              := mce.ini
-RADIOSTATESCONFFILE   := mce-radio-states.ini
-COLORPROFILESCONFFILE := mce-color-profiles.ini
+CONFFILE              := 10mce.ini
+RADIOSTATESCONFFILE   := 20mce-radio-states.ini
+COLORPROFILESCONFFILE := 20mce-color-profiles.ini
 DBUSCONF              := mce.conf
 GCONFSCHEMAS          := display.schemas energymanagement.schemas
 
@@ -251,7 +251,7 @@ MCE_PKG_NAMES += dsme
 MCE_PKG_CFLAGS := $(shell $(PKG_CONFIG) --cflags $(MCE_PKG_NAMES))
 MCE_PKG_LDLIBS := $(shell $(PKG_CONFIG) --libs   $(MCE_PKG_NAMES))
 
-MCE_CFLAGS += -DMCE_CONF_FILE=$(CONFDIR)/$(CONFFILE)
+MCE_CFLAGS += -DMCE_CONF_DIR='"$(CONFDIR)"'
 MCE_CFLAGS += $(MCE_PKG_CFLAGS)
 
 MCE_LDLIBS += $(MCE_PKG_LDLIBS)
@@ -382,8 +382,8 @@ install:: build
 	$(INSTALL_DTA) $(DBUSCONF) $(DESTDIR)$(DBUSDIR)/
 
 	$(INSTALL_DIR) $(DESTDIR)$(CONFDIR)
-	$(INSTALL_DTA) $(CONFFILE) $(DESTDIR)$(CONFDIR)/
-	$(INSTALL_DTA) $(RADIOSTATESCONFFILE) $(DESTDIR)$(CONFDIR)/
+	$(INSTALL_DTA) mce.ini $(DESTDIR)$(CONFDIR)/$(CONFFILE)
+	$(INSTALL_DTA) mce-radio-states.ini $(DESTDIR)$(CONFDIR)/$(RADIOSTATESCONFFILE)
 
 	$(INSTALL_DIR) $(DESTDIR)$(GCONFSCHEMADIR)
 	$(INSTALL_DTA) $(GCONFSCHEMAS) $(DESTDIR)$(GCONFSCHEMADIR)/

--- a/mce-conf.c
+++ b/mce-conf.c
@@ -475,12 +475,14 @@ static int mce_conf_glob_error_cb(const char *path, int err)
  */
 static GKeyFile *mce_conf_read_ini_files(void)
 {
+	static const char pattern[] = MCE_CONF_DIR"/[0-9][0-9]*.ini";
+
 	GKeyFile *ini = g_key_file_new();
 	glob_t    gb;
 
 	memset(&gb, 0, sizeof gb);
 
-	if( glob("/etc/mce/*.ini", 0, mce_conf_glob_error_cb, &gb) != 0 ) {
+	if( glob(pattern, 0, mce_conf_glob_error_cb, &gb) != 0 ) {
 		mce_log(LL_WARN, "no mce configuration ini-files found");
 		goto EXIT;
 	}


### PR DESCRIPTION
The built-in defaults are now in 10mce.ini and variant
configuration defaults in 20xxx.ini files.

Also now only inifiles that have <digit><digit> prefix are
processed.
