### PR TITLE
Synchronize MCE master radio state with connman OfflineMode property

### DIFF
--- a/modules/radiostates.c
+++ b/modules/radiostates.c
@@ -654,14 +654,11 @@ static gboolean xconnman_set_property_bool(const char *key, gboolean val)
 	if( !dbus_pending_call_set_notify(pc, xconnman_set_property_cb, 0, 0) )
 		goto EXIT;
 
-	// pending call should not be cancelled
-	pc = 0;
-
 	// success
 	res = TRUE;
 
 EXIT:
-	if( pc  ) dbus_pending_call_cancel(pc);
+	if( pc )  dbus_pending_call_unref(pc);
 	if( req ) dbus_message_unref(req);
 
 	return res;
@@ -852,14 +849,11 @@ static gboolean xconnman_get_properties(void)
 	if( !dbus_pending_call_set_notify(pc, xconnman_get_properties_cb, 0, 0) )
 		goto EXIT;
 
-	// pending call should not be cancelled
-	pc = 0;
-
 	// success
 	res = TRUE;
 
 EXIT:
-	if( pc  ) dbus_pending_call_cancel(pc);
+	if( pc )  dbus_pending_call_unref(pc);
 	if( req ) dbus_message_unref(req);
 
 	return res;
@@ -949,14 +943,11 @@ static gboolean xconnman_check_service(void)
 	if( !dbus_pending_call_set_notify(pc, xconnman_check_service_cb, 0, 0) )
 		goto EXIT;
 
-	// pending call should not be cancelled
-	pc = 0;
-
 	// success
 	res = TRUE;
 
 EXIT:
-	if( pc  ) dbus_pending_call_cancel(pc);
+	if( pc )  dbus_pending_call_unref(pc);
 	if( req ) dbus_message_unref(req);
 
 	return res;


### PR DESCRIPTION
If OfflineMode property is changed via connman, the mce master radio
state is changed accordingly and legacy mce radio state change signals
are broadcast.

If MCE master radio switch is toggled, the connman OfflineMode property
is changed accordingly.

The mce master radio state is preserved over reboots and mce restarts
and will take priority over the OfflineMode setting kept by connman.

If connman for any reason chooses not to obey OfflineMode property
change, mce will modify master radio state instead.
