### PR TITLE
Add support for display brightness control via libhybris

### DIFF
--- a/.depend
+++ b/.depend
@@ -387,6 +387,7 @@ modules/display.o:\
 	mce.h\
 	filewatcher.h\
 	libwakelock.h\
+	mce-hybris.h\
 	modules/display.h\
 	tklock.h\
 
@@ -403,6 +404,7 @@ modules/display.pic.o:\
 	mce.h\
 	filewatcher.h\
 	libwakelock.h\
+	mce-hybris.h\
 	modules/display.h\
 	tklock.h\
 


### PR DESCRIPTION
If mce-plugin-libhybris is installed and able to control
display brightness, it will be used instead of direct sysfs
writes.

[display.so] Supports display brightness control via libhybris
