### PR TITLE
Trivial fix to rpm vs Makefile version mismatch printing

### DIFF
--- a/verify_version
+++ b/verify_version
@@ -25,7 +25,7 @@ if [ "$DEB_VERS" != "$MAK_VERS" ]; then
 fi
 
 if [ "$RPM_VERS" != "$MAK_VERS" ]; then
-  echo >&2 "$MAK_PATH $MAK_VERS vs $RPM_PATH $DEB_VERS"
+  echo >&2 "$MAK_PATH $MAK_VERS vs $RPM_PATH $RPM_VERS"
   RES=1
 fi
 


### PR DESCRIPTION
In case of rpm and Makefile version mismatch code now prints Debian
version instead of rpm. This can confuse as Debian version can be correct.
