### PR TITLE
Implement double tap emulation for SDK use

### DIFF
--- a/.depend
+++ b/.depend
@@ -36,6 +36,7 @@ event-input.o:\
 	evdev.h\
 	event-input.h\
 	mce-conf.h\
+	mce-gconf.h\
 	mce-io.h\
 	mce-lib.h\
 	mce-log.h\
@@ -47,6 +48,7 @@ event-input.pic.o:\
 	evdev.h\
 	event-input.h\
 	mce-conf.h\
+	mce-gconf.h\
 	mce-io.h\
 	mce-lib.h\
 	mce-log.h\
@@ -690,6 +692,7 @@ tools/evdev_trace.pic.o:\
 
 tools/mcetool.o:\
 	tools/mcetool.c\
+	event-input.h\
 	modules/display.h\
 	modules/filter-brightness-als.h\
 	modules/powersavemode.h\
@@ -697,6 +700,7 @@ tools/mcetool.o:\
 
 tools/mcetool.pic.o:\
 	tools/mcetool.c\
+	event-input.h\
 	modules/display.h\
 	modules/filter-brightness-als.h\
 	modules/powersavemode.h\

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ ENABLE_RFS_CUD_SUPPORT ?= n
 # Whether to enable backup/restore support
 ENABLE_BACKUP_SUPPORT ?= n
 
+# Whether to enable double-click == double-tap emulation
+ENABLE_DOUBLETAP_EMULATION ?= y
+
 # Install destination
 DESTDIR               ?= /tmp/test-mce-install
 
@@ -204,6 +207,10 @@ endif
 
 ifeq ($(ENABLE_HYBRIS),y)
 CPPFLAGS += -DENABLE_HYBRIS
+endif
+
+ifeq ($(ENABLE_DOUBLETAP_EMULATION),y)
+CPPFLAGS += -DENABLE_DOUBLETAP_EMULATION
 endif
 
 # C Compiler

--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1306,6 +1306,14 @@ static const setting_t gconf_defaults[] =
     .type = "i",
     .def  = "0",
   },
+#ifdef ENABLE_DOUBLETAP_EMULATION
+  {
+    // MCE_GCONF_USE_FAKE_DOUBLETAP_PATH @ event-input.h
+    .key  = "/system/osso/dsm/event_input/use_fake_double_tap",
+    .type = "b",
+    .def  = "false",
+  },
+#endif
   {
     .key = NULL,
   }

--- a/event-input.h
+++ b/event-input.h
@@ -32,6 +32,13 @@
 /** Path to the GPIO key disable interface */
 #define GPIO_KEY_DISABLE_PATH		"/sys/devices/platform/gpio-keys/disabled_keys"
 
+/** Path to the GConf settings for the event input */
+#define MCE_GCONF_EVENT_INPUT_PATH	"/system/osso/dsm/event_input"
+
+#ifdef ENABLE_DOUBLETAP_EMULATION
+/** Path to the use Fake Double Tap setting */
+# define MCE_GCONF_USE_FAKE_DOUBLETAP_PATH MCE_GCONF_EVENT_INPUT_PATH "/use_fake_double_tap"
+#endif
 
 /**
  * Delay between I/O monitoring setups and keypress repeats; 1 second


### PR DESCRIPTION
After enabling the feature with:
  mcetool --set-fake-doubletap=enabled

The SDK emulator window can be unblanked by double clicking
within it with mouse.

[sdk] Support display unblanking via double click with mouse
