### PR TITLE
Use mce-plugin-libhybris for indicator led control

### DIFF
--- a/.depend
+++ b/.depend
@@ -550,6 +550,7 @@ modules/led.o:\
 	mce-lib.h\
 	mce-log.h\
 	mce.h\
+	mce-hybris.h\
 	modules/led.h\
 
 modules/led.pic.o:\
@@ -564,6 +565,7 @@ modules/led.pic.o:\
 	mce-lib.h\
 	mce-log.h\
 	mce.h\
+	mce-hybris.h\
 	modules/led.h\
 
 modules/powersavemode.o:\

--- a/Makefile
+++ b/Makefile
@@ -404,6 +404,7 @@ install:: build
 	$(INSTALL_DIR) $(DESTDIR)$(CONFDIR)
 	$(INSTALL_DTA) inifiles/mce.ini $(DESTDIR)$(CONFDIR)/$(CONFFILE)
 	$(INSTALL_DTA) inifiles/mce-radio-states.ini $(DESTDIR)$(CONFDIR)/$(RADIOSTATESCONFFILE)
+	$(INSTALL_DTA) inifiles/hybris-led.ini $(DESTDIR)$(CONFDIR)/20hybris-led.ini
 
 ifneq ($(strip $(ENABLE_BUILTIN_GCONF)),y)
 	$(INSTALL_DIR) $(DESTDIR)$(GCONFSCHEMADIR)

--- a/inifiles/hybris-led.ini
+++ b/inifiles/hybris-led.ini
@@ -1,0 +1,30 @@
+[LEDPatternHybris]
+
+# Patterns used for the hybris hardware;
+# Please prefix pattern names with Pattern to avoid name space clashes
+#
+# [0] Priority (0 - highest, 255 - lowest)
+# [1] ScreenOn - 0 only show pattern when the display is off
+#            1 show pattern even when the display is on
+#            2 only show pattern when the display is off, including acting dead
+#            3 show pattern even when the display is on, including acting dead
+#            4 only show pattern if the display is off, or if in acting dead
+#            5 always show pattern, even if LED disabled
+# [2] Timeout in seconds before pattern is disabled, 0 for infinite
+# [3] OnPeriod in milliseconds
+# [4] OffPeriod in milliseconds
+# [5] RGB24 as hexadecimal number
+
+PatternDeviceOn=254;0;0;666;334;0000ff
+PatternDeviceSoftOff=253;0;0;666;334;00ff00
+PatternPowerOn=9;3;0;666;334;00ffff
+PatternPowerOff=10;3;0;666;334;ff0000
+PatternCommunication=30;1;0;666;334;ff00ff
+PatternCommunicationCall=30;1;0;666;334;ffff00
+PatternCommunicationIM=30;1;0;666;334;ffffff
+PatternCommunicationSMS=30;1;0;666;334;00007f
+PatternCommunicationEmail=30;1;0;666;334;007f00
+PatternCommonNotification=30;1;0;666;334;007f7f
+PatternWebcamActive=20;1;0;666;334;7f0000
+PatternBatteryCharging=50;4;0;666;334;7f007f
+PatternBatteryFull=40;4;0;666;334;7f7f00

--- a/modules/filter-brightness-als.c
+++ b/modules/filter-brightness-als.c
@@ -331,6 +331,30 @@ static als_profile_struct display_als_profiles_hybris[] =
 		{  30,  60, 100, 100, },
 	},
 };
+
+/**
+ * ALS profile for the libhybris LED:
+ */
+static als_profile_struct led_als_profiles_hybris[] = {
+	/* Minimum; unused */
+	{ { { -1, -1 } }, { 100 } },
+	/* Economy; unused */
+	{ { { -1, -1 } }, { 100 } },
+	/* Normal; copied from rm696 */
+	{
+		{
+			{  3,  5 }, // 0
+			{ -1, -1 }, // 1
+		},
+		// 0    1
+		{ 80, 100 }
+	},
+	/* Bright; unused */
+	{ { { -1, -1 } }, { 100 } },
+	/* Maximum; unused */
+	{ { { -1, -1 } }, { 100 } },
+};
+
 #endif /* ENABLE_HYBRIS */
 
 /**
@@ -987,6 +1011,7 @@ static als_type_t get_als_type(void)
 
 		// FIXME: uses rm696 profile data, need real ones
 		display_als_profiles = display_als_profiles_hybris;
+		led_als_profiles     = led_als_profiles_hybris;
 	}
 #endif
 	else {

--- a/modules/led.h
+++ b/modules/led.h
@@ -68,6 +68,11 @@
  */
 #define MCE_CONF_LED_PATTERN_RM696_GROUP	"LEDPatternNJoyRM696"
 
+/**
+ * Name of LED RGB pattern configuration group for libhybris
+ */
+#define MCE_CONF_LED_PATTERN_HYBRIS_GROUP	"LEDPatternHybris"
+
 /** Path to the GConf settings for the display */
 #define MCE_GCONF_LED_PATH			"/system/osso/dsm/leds"
 
@@ -94,6 +99,8 @@
 /** Maximum Lysti (LP5523)-controlled monochrome LED current */
 #define MAXIMUM_LYSTI_MONOCHROME_LED_CURRENT	100	/* 10.0 mA */
 
+/** Maximum libhybris led brightness */
+#define MAXIMUM_HYBRIS_LED_BRIGHTNESS		100	/* % */
 
 /** Path to the mono LED /sys directory */
 #define MCE_MONO_LED_SYS_PATH			"/sys/class/leds/keypad"

--- a/rpm/mce.spec
+++ b/rpm/mce.spec
@@ -72,6 +72,7 @@ systemctl daemon-reload
 %dir %config %{_sysconfdir}/%{name}
 %config %{_sysconfdir}/%{name}/10mce.ini
 %config %{_sysconfdir}/%{name}/20mce-radio-states.ini
+%config %{_sysconfdir}/%{name}/20hybris-led.ini
 # empty /var/lib/mce -> rpm
 %dir %{_localstatedir}/lib/%{name}/
 # NB empty /var/run/mce -> handled by systemd tmpfiles.d/mce.conf


### PR DESCRIPTION
If mce-plugin-libhybris is installed and support for indicator
led is available, the mce led plugin will utilize it.

[mce] Support led patterns via mce-plugin-libhybris
