### PR TITLE
enable display on/off handling in actdead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ distclean:: clean
 # CONFIGURATION
 # ----------------------------------------------------------------------------
 
-VERSION := 1.12.19
+VERSION := 1.12.18
 
 INSTALL_BIN := install --mode=755
 INSTALL_DIR := install -d

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-mce (1.12.19) unstable; urgency=low
-
-  * [display] enable display on/off handling in actdead
-
- -- Pekka Lundstrom <pekka.lundstrom@jollamobile.com>  Thu, 15 Aug 2013 18:01:08 +0300
-
 mce (1.12.18) unstable; urgency=low
 
   * [mce] Add runtime configuration for disabling led patterns

--- a/rpm/mce.spec
+++ b/rpm/mce.spec
@@ -1,6 +1,6 @@
 Name:       mce
 Summary:    Mode Control Entity for Nokia mobile computers
-Version:    1.12.19
+Version:    1.12.18
 Release:    1
 Group:      System/System Control
 License:    LGPLv2


### PR DESCRIPTION
This allows mce to handle display on/off/dim states same as in user state.
While in actdead:
- Timeout will first dim then turn off the display.
- Touch, tap or powerbutton will wake up the display.
