### PR TITLE
Set proximity sensor default value to COVER_OPEN

### DIFF
--- a/mce.c
+++ b/mce.c
@@ -945,7 +945,7 @@ int main(int argc, char **argv)
 	setup_datapipe(&lens_cover_pipe, READ_ONLY, DONT_FREE_CACHE,
 		       0, GINT_TO_POINTER(0));
 	setup_datapipe(&proximity_sensor_pipe, READ_ONLY, DONT_FREE_CACHE,
-		       0, GINT_TO_POINTER(0));
+		       0, GINT_TO_POINTER(COVER_OPEN));
 	setup_datapipe(&tk_lock_pipe, READ_ONLY, DONT_FREE_CACHE,
 		       0, GINT_TO_POINTER(LOCK_UNDEF));
 	setup_datapipe(&charger_state_pipe, READ_ONLY, DONT_FREE_CACHE,


### PR DESCRIPTION
Using zero (=COVER_CLOSED) combined with failure to get data from the
proximity sensor caused misfiring proximity blanking during phone calls.
