### PR TITLE
Fix dbus name owner monitoring

### DIFF
--- a/mce-dbus.c
+++ b/mce-dbus.c
@@ -1555,7 +1555,9 @@ static GSList *find_monitored_service(const gchar *service,
 	if (service == NULL)
 		goto EXIT;
 
-	if ((rule = g_strdup_printf("arg1='%s'", service)) == NULL)
+	/* Signal content: arg0=name, arg1=old owner, arg2=new owner.
+	 * In This case  we want to track loss of name owner. */
+	if ((rule = g_strdup_printf("arg0='%s',arg2=''", service)) == NULL)
 		goto EXIT;
 
 	tmp = g_slist_find_custom(monitor_list, rule, monitor_compare);
@@ -1600,6 +1602,8 @@ static gboolean fake_owner_gone(gpointer data)
 				 DBUS_TYPE_INVALID);
 
 	msg_handler(NULL, msg, NULL);
+
+	dbus_message_unref(msg), msg = 0;
 
 	return FALSE;
 }
@@ -1657,7 +1661,9 @@ gssize mce_dbus_owner_monitor_add(const gchar *service,
 	if ((num = g_slist_length(*monitor_list)) == max_num)
 		goto EXIT;
 
-	if ((rule = g_strdup_printf("arg1='%s'", service)) == NULL)
+	/* Signal content: arg0=name, arg1=old owner, arg2=new owner.
+	 * In This case  we want to track loss of name owner. */
+	if ((rule = g_strdup_printf("arg0='%s',arg2=''", service)) == NULL)
 		goto EXIT;
 
 	/* Add ownership monitoring for the service */

--- a/modules/alarm.c
+++ b/modules/alarm.c
@@ -110,7 +110,7 @@ static gboolean alarm_owner_monitor_dbus_cb(DBusMessage *const msg)
 		goto EXIT;
 	}
 
-	retval = mce_dbus_owner_monitor_remove(old_name, &alarm_owner_monitor_list);
+	retval = mce_dbus_owner_monitor_remove(service, &alarm_owner_monitor_list);
 
 	if (retval == 0) {
 		/* We didn't get alarm off from the same service before it

--- a/modules/callstate.c
+++ b/modules/callstate.c
@@ -243,7 +243,7 @@ static gboolean call_state_owner_monitor_dbus_cb(DBusMessage *const msg)
 	}
 
 	/* Remove the name monitor for the call state requester */
-	if (mce_dbus_owner_monitor_remove(old_name,
+	if (mce_dbus_owner_monitor_remove(service,
 					  &call_state_monitor_list) == 0) {
 		/* Signal the new call state/type */
 		send_call_state(NULL, MCE_CALL_STATE_NONE, MCE_NORMAL_CALL);

--- a/modules/display.c
+++ b/modules/display.c
@@ -3142,7 +3142,7 @@ static gboolean blanking_pause_owner_monitor_dbus_cb(DBusMessage *const msg)
 		goto EXIT;
 	}
 
-	remove_blanking_pause(old_name);
+	remove_blanking_pause(service);
 	status = TRUE;
 
 EXIT:

--- a/modules/displaymeego.c
+++ b/modules/displaymeego.c
@@ -1283,7 +1283,7 @@ static gboolean blanking_pause_owner_monitor_dbus_cb(DBusMessage *const msg)
 		goto EXIT;
 	}
 
-	remove_blanking_pause(old_name);
+	remove_blanking_pause(service);
 	status = TRUE;
 
 EXIT:

--- a/modules/filter-brightness-als.c
+++ b/modules/filter-brightness-als.c
@@ -2029,7 +2029,7 @@ static gboolean als_owner_monitor_dbus_cb(DBusMessage *const msg)
 	}
 
 	/* Remove the name monitor for the ALS owner */
-	retval = mce_dbus_owner_monitor_remove(old_name, &als_owner_monitor_list);
+	retval = mce_dbus_owner_monitor_remove(service, &als_owner_monitor_list);
 
 	if (retval == -1) {
 		mce_log(LL_INFO,

--- a/modules/inactivity.c
+++ b/modules/inactivity.c
@@ -244,7 +244,7 @@ static gboolean activity_cb_monitor_dbus_cb(DBusMessage *const msg)
 		goto EXIT;
 	}
 
-	remove_activity_cb(old_name);
+	remove_activity_cb(service);
 	status = TRUE;
 
 EXIT:

--- a/modules/proximity.c
+++ b/modules/proximity.c
@@ -787,12 +787,12 @@ static gboolean proximity_sensor_owner_monitor_dbus_cb(DBusMessage *const msg)
 	}
 
 	/* Remove the name monitor for the proximity sensor owner */
-	retval = mce_dbus_owner_monitor_remove(old_name, &proximity_sensor_owner_monitor_list);
+	retval = mce_dbus_owner_monitor_remove(service, &proximity_sensor_owner_monitor_list);
 
 	if (retval == -1) {
 		mce_log(LL_INFO,
 			"Failed to remove name owner monitoring for `%s'",
-			old_name);
+			service);
 	} else {
 		if ((ps_external_refcount > 0) && (retval == 0)) {
 			if (ps_onoff_mode_output.path != NULL)


### PR DESCRIPTION
The NameOwnerChanged signal content is
- arg0 the dbus name that has changed ownership
- arg1 the private dbus name of the previous owner
- arg2 the private dbus name of the current owner

To catch loss of name owner, we want to receive signals
where arg0 is the name we are interested in and arg2 is
an empty string.

Also fixes memory leak in fake_owner_gone()
