### PR TITLE
Make proximity sensor usage optional

### DIFF
--- a/.depend
+++ b/.depend
@@ -603,6 +603,7 @@ modules/proximity.o:\
 	datapipe.h\
 	datapipe.h\
 	mce-dbus.h\
+	mce-gconf.h\
 	mce-hal.h\
 	mce-io.h\
 	mce-log.h\
@@ -616,6 +617,7 @@ modules/proximity.pic.o:\
 	datapipe.h\
 	datapipe.h\
 	mce-dbus.h\
+	mce-gconf.h\
 	mce-hal.h\
 	mce-io.h\
 	mce-log.h\
@@ -708,6 +710,7 @@ tools/mcetool.o:\
 	modules/display.h\
 	modules/filter-brightness-als.h\
 	modules/powersavemode.h\
+	modules/proximity.h\
 	systemui/dbus-names.h\
 	systemui/tklock-dbus-names.h\
 	tklock.h\
@@ -718,6 +721,7 @@ tools/mcetool.pic.o:\
 	modules/display.h\
 	modules/filter-brightness-als.h\
 	modules/powersavemode.h\
+	modules/proximity.h\
 	systemui/dbus-names.h\
 	systemui/tklock-dbus-names.h\
 	tklock.h\

--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1398,6 +1398,12 @@ static const setting_t gconf_defaults[] =
     .def  = "true",
   },
   {
+    // MCE_GCONF_PROXIMITY_PS_ENABLED_PATH @ proximity.h
+    .key  = "/system/osso/dsm/proximity/ps_enabled",
+    .type = "b",
+    .def  = "true",
+  },
+  {
     .key  = NULL,
   }
 };

--- a/mce-sensorfw.c
+++ b/mce-sensorfw.c
@@ -644,6 +644,8 @@ static void mce_sensorfw_als_read_cb(DBusPendingCall *pc, void *aptr)
 	dbus_message_iter_get_basic(&rec, &lux);
 	dbus_message_iter_next(&rec);
 
+	mce_log(LL_INFO, "initial ALS value = %u", lux);
+
 	if( als_notify )
 		als_notify(lux);
 	else
@@ -871,6 +873,8 @@ static void mce_sensorfw_ps_read_cb(DBusPendingCall *pc, void *aptr)
 
 	dbus_message_iter_get_basic(&rec, &dst);
 	dbus_message_iter_next(&rec);
+
+	mce_log(LL_INFO, "initial PS value = %u", dst);
 
 	if( ps_notify )
 		ps_notify(dst > 0);

--- a/modules/proximity.h
+++ b/modules/proximity.h
@@ -91,15 +91,13 @@ typedef struct {
 	guint threshold_falling;
 } hysteresis_t;
 
-/** Proximity threshold for the Dipro proximity sensor */
-static hysteresis_t dipro_ps_threshold_dipro = {
-	/** Rising hysteresis threshold for Dipro */
-	.threshold_rising = 80,
-	/** Falling hysteresis threshold for Dipro */
-	.threshold_falling = 70,
-};
-
 /** Sysinfo identifier for the proximity sensor calibration values */
 #define PS_CALIB_IDENTIFIER		"/device/ps_calib"
+
+
+/** Path to the GConf settings for the proximity */
+#define MCE_GCONF_PROXIMITY_PATH		"/system/osso/dsm/proximity"
+/** Path to the ALS enabled GConf setting */
+#define MCE_GCONF_PROXIMITY_PS_ENABLED_PATH	MCE_GCONF_PROXIMITY_PATH "/ps_enabled"
 
 #endif /* _PROXIMITY_H_ */

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -42,6 +42,7 @@
 #include "../modules/display.h"
 #include "../modules/powersavemode.h"
 #include "../modules/filter-brightness-als.h"
+#include "../modules/proximity.h"
 #include "../systemui/tklock-dbus-names.h"
 #include "../systemui/dbus-names.h"
 
@@ -1969,6 +1970,33 @@ static void xmce_get_adaptive_dimming_time(void)
 }
 
 /* ------------------------------------------------------------------------- *
+ * ps
+ * ------------------------------------------------------------------------- */
+
+/* Set ps use mode
+ *
+ * @param args string suitable for interpreting as enabled/disabled
+ */
+static void xmce_set_ps_mode(const char *args)
+{
+        debugf("%s(%s)\n", __FUNCTION__, args);
+        gboolean val = xmce_parse_enabled(args);
+        mcetool_gconf_set_bool(MCE_GCONF_PROXIMITY_PS_ENABLED_PATH, val);
+}
+
+/** Get current ps mode from mce and print it out
+ */
+static void xmce_get_ps_mode(void)
+{
+        gboolean val = 0;
+        char txt[32] = "unknown";
+
+        if( mcetool_gconf_get_bool(MCE_GCONF_PROXIMITY_PS_ENABLED_PATH, &val) )
+                snprintf(txt, sizeof txt, "%s", val ? "enabled" : "disabled");
+        printf("%-"PAD1"s %s\n", "Use ps mode:", txt);
+}
+
+/* ------------------------------------------------------------------------- *
  * als
  * ------------------------------------------------------------------------- */
 
@@ -2575,6 +2603,7 @@ static void xmce_get_status(void)
         xmce_get_doubletap_mode();
         xmce_get_low_power_mode();
         xmce_get_als_mode();
+        xmce_get_ps_mode();
         xmce_get_dim_timeouts();
         xmce_get_suspend_policy();
         xmce_get_cpu_scaling_governor();
@@ -2740,6 +2769,9 @@ EXTRA"  valid values are: 1-5\n"
 PARAM"-g, --set-als-mode=<enabled|disabled>\n"
 EXTRA"set the als mode; valid modes are:\n"
 EXTRA"  'enabled' and 'disabled'\n"
+PARAM"-u, --set-ps-mode=<enabled|disabled>\n"
+EXTRA"set the ps mode; valid modes are:\n"
+EXTRA"  'enabled' and 'disabled'\n"
 PARAM"-a, --get-color-profile-ids\n"
 EXTRA"get available color profile ids\n"
 PARAM"-A, --set-color-profile=ID\n"
@@ -2851,7 +2883,7 @@ PROG_NAME" v"G_STRINGIFY(PRG_VERSION)"\n"
 ;
 
 // Unused short options left ....
-// - - - - - - - - - - - - - - - - - - - - u - w x - z
+// - - - - - - - - - - - - - - - - - - - - - - w x - z
 // - - - - - - - - - - - - - - - - - - - - - - W X - Z
 
 const char OPT_S[] =
@@ -2899,6 +2931,7 @@ const char OPT_S[] =
 "m:"  // --tklock-callback
 "q:"  // --tklock-open
 "Q"   // --tklock-close
+"u:"  // --set-ps-mode
 #ifdef ENABLE_DOUBLETAP_EMULATION
 "i:"  // --set-fake-doubletap
 #endif
@@ -2942,6 +2975,7 @@ struct option const OPT_L[] =
         { "set-adaptive-dimming-time", 1, 0, 'J' }, // xmce_set_adaptive_dimming_time()
         { "set-low-power-mode",        1, 0, 'E' }, // xmce_set_low_power_mode()
         { "set-als-mode",              1, 0, 'g' }, // xmce_set_als_mode()
+        { "set-ps-mode",               1, 0, 'u' }, // xmce_set_ps_mode()
         { "set-dim-timeout",           1, 0, 'G' }, // xmce_set_dim_timeout()
         { "set-never-blank",           1, 0, 'j' }, // xmce_set_never_blank()
         { "set-blank-timeout",         1, 0, 'o' }, // xmce_set_blank_timeout()
@@ -3022,6 +3056,7 @@ int main(int argc, char **argv)
 #endif
                 case 'b': xmce_set_display_brightness(optarg);    break;
                 case 'g': xmce_set_als_mode(optarg);              break;
+                case 'u': xmce_set_ps_mode(optarg);               break;
 
                 case 'a': xmce_get_color_profile_ids();           break;
                 case 'A': xmce_set_color_profile(optarg);         break;


### PR DESCRIPTION
Built in default is: use proximity sensor

Can be toggled with: mcetool --set-ps-mode=<enabled|disabled>
