### PR TITLE
Fix adaptive dimming timeout

### DIFF
--- a/modules/display.c
+++ b/modules/display.c
@@ -1890,8 +1890,8 @@ static void setup_adaptive_dimming_timeout(void)
 
 	/* Setup new timeout */
 	adaptive_dimming_timeout_cb_id =
-		g_timeout_add_seconds(adaptive_dimming_threshold,
-				      adaptive_dimming_timeout_cb, NULL);
+		g_timeout_add(adaptive_dimming_threshold,
+			      adaptive_dimming_timeout_cb, NULL);
 
 EXIT:
 	return;


### PR DESCRIPTION
adaptive_dimming_threshold is specified in milliseconds.

Relates NEMO#701

[mce] Fix adaptive dimming timeout
