### PR TITLE
Use 40% led brightness if als tuning is not enabled

### DIFF
--- a/modules/filter-brightness-als.c
+++ b/modules/filter-brightness-als.c
@@ -566,7 +566,7 @@ EXIT:
 static gpointer led_brightness_filter(gpointer data)
 {
 	int value = GPOINTER_TO_INT(data);
-	int scale = 100;
+	int scale = 40;
 
 	if( als_lux_latest < 0 )
 		goto EXIT;


### PR DESCRIPTION
Using 100% is likely to be too bright and consume too much power
