### PR TITLE
Allow more time for setUpdatesEnabled ipc roundtrip

### DIFF
--- a/modules/display.c
+++ b/modules/display.c
@@ -3555,8 +3555,8 @@ static waitfb_t mdy_waitfb_data =
 #define RENDERER_IFACE    "org.nemomobile.lipstick"
 #define RENDERER_SET_UPDATES_ENABLED "setUpdatesEnabled"
 
-/** For how long we allow ui side to delay suspending [ms]; -1 = use default */
-static int mdy_renderer_ipc_timeout = 30 * 1000;
+/** Timeout to use for setUpdatesEnabled method calls [ms]; -1 = use default */
+static int mdy_renderer_ipc_timeout = 2 * 60 * 1000; /* 2 minutes */
 
 /** UI side rendering state; no suspend unless RENDERER_DISABLED */
 static renderer_state_t mdy_renderer_ui_state = RENDERER_UNKNOWN;


### PR DESCRIPTION
With severe enough cpu/dbus congestion we might end up in a situation
where lipstick gets setUpdatesEnabled(true) dbus method call, but the
reply message does not get back to mce in time and thus gets discarded.

In the worst cases the following re-tries might get timeout too, which
means that getting mce and lipstick back to sync can take much longer
than it needs to.

Using severely pessimistic timeout value does no harm, but makes it
less likely that valid replies are discarded -> use 2 minutes for now.
