### PR TITLE
Hold wakelock while there are active power key related timers

### DIFF
--- a/.depend
+++ b/.depend
@@ -687,6 +687,7 @@ modules/radiostates.pic.o:\
 powerkey.o:\
 	powerkey.c\
 	datapipe.h\
+	libwakelock.h\
 	mce-conf.h\
 	mce-dbus.h\
 	mce-dsme.h\
@@ -697,6 +698,7 @@ powerkey.o:\
 powerkey.pic.o:\
 	powerkey.c\
 	datapipe.h\
+	libwakelock.h\
 	mce-conf.h\
 	mce-dbus.h\
 	mce-dsme.h\

--- a/mce.c
+++ b/mce.c
@@ -288,6 +288,7 @@ static void mce_cleanup_wakelocks(void)
 	wakelock_unlock("mce_input_handler");
 	wakelock_unlock("mce_cpu_keepalive");
 	wakelock_unlock("mce_display_stm");
+	wakelock_unlock("mce_powerkey_stm");
 }
 #endif // ENABLE_WAKELOCKS
 


### PR DESCRIPTION
There is a state machine for separating short, long and double
power key presses. The detection logic uses timers, and we need
to ensure the device does not fall back to suspend while the
timers are active.
