### PR TITLE
Always log double tap and power key event processing in devel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ endif
 endif
 PKG_CONFIG   ?= pkg-config
 
+# Whether to enable DEVEL release logging
+ENABLE_DEVEL_LOGGING ?= y
+
 # Whether to use sensorfw for ALS/PS
 ENABLE_SENSORFW ?= y
 
@@ -243,6 +246,10 @@ endif
 
 ifeq ($(ENABLE_DOUBLETAP_EMULATION),y)
 CPPFLAGS += -DENABLE_DOUBLETAP_EMULATION
+endif
+
+ifeq ($(ENABLE_DEVEL_LOGGING),y)
+CPPFLAGS += -DENABLE_DEVEL_LOGGING
 endif
 
 # C Compiler

--- a/event-input.c
+++ b/event-input.c
@@ -1180,6 +1180,21 @@ EXIT:
 	return flush;
 }
 
+/** Proximity state enum to human readable string
+ */
+static const char *proximity_state_repr(cover_state_t state)
+{
+	const char *repr = "unknown";
+	switch( state ) {
+	case COVER_UNDEF:  repr = "undefined";   break;
+	case COVER_CLOSED: repr = "covered";     break;
+	case COVER_OPEN:   repr = "not covered"; break;
+	default:
+		break;
+	}
+	return repr;
+}
+
 static gboolean doubletap_iomon_cb(gpointer data, gsize bytes_read)
 {
 	struct input_event *ev = data;
@@ -1197,16 +1212,14 @@ static gboolean doubletap_iomon_cb(gpointer data, gsize bytes_read)
 		cover_state_t proximity_sensor_state =
 			datapipe_get_gint(proximity_sensor_pipe);
 
+		mce_log(LL_DEVEL, "[doubletap] while proximity=%s",
+			proximity_state_repr(proximity_sensor_state));
+
 		if( proximity_sensor_state == COVER_CLOSED ) {
-			/* As we should disable double tap detector rather
-			 * than filtering the events with proximity state.
-			 * Emit one warning then switch to debug logging */
-			static loglevel_t lev =	LL_WARN;
-			mce_log(lev, "IGNORING DOUBLETAP");
-			lev = LL_DEBUG;
+			mce_log(LL_DEVEL, "[doubletap] ignored");
 		}
 		else {
-			mce_log(LL_NOTICE, "FORWARDING DOUBLETAP");
+			mce_log(LL_DEVEL, "[doubletap] forwarded");
 			/* Mimic N9 style gesture event for which we
 			 * already have logic in place */
 			ev->type  = EV_MSC;

--- a/mce-log.h
+++ b/mce-log.h
@@ -38,6 +38,13 @@ typedef enum {
 	LL_DEBUG   = 7,			/**< Useful when debugging */
 
 	LL_DEFAULT = LL_WARN,		/**< Default log level */
+
+#ifdef ENABLE_DEVEL_LOGGING
+	LL_DEVEL   = LL_CRIT,		/**< Log by default on devel build */
+#else
+	LL_DEVEL   = LL_NOTICE,		/**< Otherwise verbose mode needed */
+#endif
+
 } loglevel_t;
 
 void mce_log_add_pattern(const char *pat);

--- a/powerkey.c
+++ b/powerkey.c
@@ -163,6 +163,9 @@ EXIT:
 static void generic_powerkey_handler(poweraction_t action,
 				     gchar *dbus_signal)
 {
+	mce_log(LL_DEVEL, "action=%d, signal=%s", (int)action,
+		dbus_signal ?: "n/a");
+
 	alarm_ui_state_t alarm_ui_state =
 				datapipe_get_gint(alarm_ui_state_pipe);
 	submode_t submode = mce_get_submode_int32();
@@ -182,13 +185,9 @@ static void generic_powerkey_handler(poweraction_t action,
 		 * or if we're in alarm state
 		 */
 		if ((submode & MCE_TKLOCK_SUBMODE) == 0) {
-			mce_log(LL_WARN,
-				"Requesting shutdown (action: %d)",
-				action);
-
+			mce_log(LL_DEVEL, "Requesting shutdown");
 			request_normal_shutdown();
 		}
-
 		break;
 
 	case POWER_SOFT_POWEROFF:
@@ -214,7 +213,7 @@ static void generic_powerkey_handler(poweraction_t action,
 			 * or powering up will bounce back to display off
 			 * once initial the off->on transition finishes */
 
-			mce_log(LL_DEBUG, "display -> off + lock");
+			mce_log(LL_DEVEL, "display -> off, ui -> locked");
 
 			/* Do the locking before turning display off.
 			 *
@@ -234,7 +233,7 @@ static void generic_powerkey_handler(poweraction_t action,
 			/* If the display is not fully powered on, always
 			 * request MCE_DISPLAY_ON */
 
-			mce_log(LL_DEBUG, "display -> on");
+			mce_log(LL_DEVEL, "display -> on");
 			execute_datapipe(&display_state_req_pipe,
 					 GINT_TO_POINTER(MCE_DISPLAY_ON),
 					 USE_INDATA, CACHE_INDATA);
@@ -619,7 +618,7 @@ static void powerkey_trigger(gconstpointer const data)
 	if ((ev != NULL) && (ev->code == KEY_POWER)) {
 		/* If set, the [power] key was pressed */
 		if (ev->value == 1) {
-			mce_log(LL_DEBUG, "[power] pressed");
+			mce_log(LL_DEVEL, "[powerkey] pressed");
 
 			/* Are we waiting for a doublepress? */
 			if (doublepress_timeout_cb_id != 0) {
@@ -636,7 +635,7 @@ static void powerkey_trigger(gconstpointer const data)
 				setup_powerkey_timeout(longdelay);
 			}
 		} else if (ev->value == 0) {
-			mce_log(LL_DEBUG, "[power] released");
+			mce_log(LL_DEVEL, "[powerkey] released");
 
 			/* Short key press */
 			if (powerkey_timeout_cb_id != 0) {

--- a/rpm/mce.spec
+++ b/rpm/mce.spec
@@ -50,7 +50,7 @@ This package contains test suite for mce
 
 %build
 ./verify_version
-make %{?jobs:-j%jobs}
+make %{?jobs:-j%jobs} %{!?qa_stage_devel:ENABLE_DEVEL_LOGGING=n}
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
This needs to be scaled down once all power key and double tap wake
up problems have been resolved.
