### PR TITLE
Fix file descriptor leak

### DIFF
--- a/mce-dbus.c
+++ b/mce-dbus.c
@@ -2474,6 +2474,8 @@ static void mce_dbus_ident_update_exe(mce_dbus_ident_t *self)
     self->ni_exe = strdup((char *)text);
 
 EXIT:
+    if( file != -1 ) close(file);
+
     return;
 }
 


### PR DESCRIPTION
The /proc/PID/cmdline files opened for client identification purposes
were left open.

[mce] Fix file descriptor leak
