### PR TITLE
Add option for disabling power key when proximity is covered

### DIFF
--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1501,6 +1501,12 @@ static const setting_t gconf_defaults[] =
     .def  = "2",
   },
   {
+    // MCE_GCONF_POWERKEY_MODE @ powerkey.h
+    .key  = "/system/osso/dsm/powerkey/mode",
+    .type = "i",
+    .def  = "1",
+  },
+  {
     .key  = NULL,
   }
 };

--- a/powerkey.h
+++ b/powerkey.h
@@ -23,6 +23,27 @@
 
 #include <glib.h>
 
+/** Path to the GConf settings for the powerkey module */
+# define MCE_GCONF_POWERKEY_PATH       "/system/osso/dsm/powerkey"
+
+/** Path to the powerkey  mode GConf setting */
+# define MCE_GCONF_POWERKEY_MODE       MCE_GCONF_POWERKEY_PATH "/mode"
+
+/** Power key action enable modes */
+typedef enum
+{
+        /** Power key actions disabled */
+        PWRKEY_ENABLE_NEVER,
+
+        /** Power key actions always enabled */
+        PWRKEY_ENABLE_ALWAYS,
+
+        /** Power key actions enabled when PS is not covered */
+        PWRKEY_ENABLE_NO_PROXIMITY,
+
+        PWRKEY_ENABLE_DEFAULT = PWRKEY_ENABLE_ALWAYS,
+} pwrkey_mode_t;
+
 /** Configuration value used for the disabled policy */
 #define POWER_DISABLED_STR				"disabled"
 /** Configuration value used for the device menu policy */


### PR DESCRIPTION
Similarly to double tap, also power key actions can now be
- always allowed
- never allowed
- allowed if proximity sensor is not covered

Default is "always", i.e. power key works the same way as before.

The setting can be changed via mcetool option
  -Z, --set-powerkey-action=<never|always|proximity>

The setting persists over mce / device restarts.

[mce] Add option for disabling power key when proximity is covered
