### PR TITLE
[systemd] Fixed mce start dependency. JB#15511

### DIFF
--- a/systemd/mce.service
+++ b/systemd/mce.service
@@ -3,7 +3,6 @@ Description=Mode Control Entity (MCE)
 Requires=dsme.service
 Requires=dbus.service
 After=dsme.service
-Before=start-user-session@USER.service start-user-session@ACT_DEAD.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
With new systemd we don't have anymore start-user-session@USER.service
We could fix this by using 
Before=start-user-session.service
but we don't need any start dependency in mce as start-user-session.service has this
After=mce.service
that is all we need

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
