### PR TITLE
Tune PowerOff led pattern priority

### DIFF
--- a/inifiles/hybris-led.ini
+++ b/inifiles/hybris-led.ini
@@ -33,7 +33,7 @@ PatternDisplayDimmed=252;7;0;0;0;001f1f
 PatternPowerOn=10;3;0;0;0;bfbfbf
 #bfbfbf = grey75
 
-PatternPowerOff=9;3;0;0;0;ff0000
+PatternPowerOff=8;3;0;0;0;ff0000
 # ff0000 = red
 
 PatternCommunication=30;6;0;500;1500;ff00ff


### PR DESCRIPTION
The led testing patterns have priority of 9. Since the shutdown
indication should have the highest priority, adjust the PowerOff
led pattern to priority 8.
