### PR TITLE
Leave touch panel powered on during incall proximity blanking

### DIFF
--- a/modules/doubletap.h
+++ b/modules/doubletap.h
@@ -1,5 +1,5 @@
 /* ------------------------------------------------------------------------- *
- * Copyright (C) 2013 Jolla Ltd.
+ * Copyright (C) 2013-2014 Jolla Ltd.
  * Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
  * License: LGPLv2
  * ------------------------------------------------------------------------- */
@@ -22,11 +22,20 @@ extern "C" {
 /** Name of the configuration key for doubletap enable value */
 # define MCE_CONF_DOUBLETAP_ENABLE_VALUE "EnableValue"
 
-/** Name of the configuration key for doubletap disable, touch powered off value */
+/** Name of the configuration key for doubletap disable value */
 # define MCE_CONF_DOUBLETAP_DISABLE_VALUE "DisableValue"
 
-/** Name of the configuration key for doubletap disable, touch powered on value */
-# define MCE_CONF_DOUBLETAP_DISABLE_NO_SLEEP_VALUE "DisableNoSleepValue"
+/** Name of touch panel ini file configuration group */
+# define MCE_CONF_TPSLEEP_GROUP        "TouchPanelSleep"
+
+/** Name of the configuration key for touch panel sleep control file */
+# define MCE_CONF_TPSLEEP_CONTROL_PATH "ControlPath"
+
+/** Name of the configuration key for touch panel sleep allowed value */
+# define MCE_CONF_TPSLEEP_ALLOW_VALUE  "AllowValue"
+
+/** Name of the configuration key for touch panel sleep denied value */
+# define MCE_CONF_TPSLEEP_DENY_VALUE   "DenyValue"
 
 /** Path to the GConf settings for the doubletap module */
 # define MCE_GCONF_DOUBLETAP_PATH       "/system/osso/dsm/doubletap"


### PR DESCRIPTION
Neither double tap not touch events are generated, but the touch panel
is kept powered on. This makes the touch detection work more reliably
when display is unblanked again - which in turn makes it more likely
that we can block ui from seeing stray touch events if proximity sensor
is briefly uncovered while phone is at ear.

Previously there was a prototype kernel side implementation that used
single sysfs control path for setting both double tap and sleep mode.
Now there are separate control files and logic is adjusted accordingly.
