### PR TITLE
Enter display off state after dimming

### DIFF
--- a/modules/display.c
+++ b/modules/display.c
@@ -2851,7 +2851,7 @@ static void mdy_blanking_rethink_timers(bool force)
         if( charger_connected &&
             mdy_blanking_inhibit_mode == INHIBIT_STAY_DIM_WITH_CHARGER )
             break;
-        mdy_blanking_schedule_lpm_on();
+        mdy_blanking_schedule_off();
         break;
 
     case MCE_DISPLAY_ON:


### PR DESCRIPTION
The logic inherited from N9 went to lpm_on state if low power mode
is enabled. This is not desirable because lpm display states require
locking of ui, which in turn cancels grace period that allows users
to get back to previously open application.
