### PR TITLE
Enable use_low_power_mode setting by default

### DIFF
--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1268,7 +1268,7 @@ static const setting_t gconf_defaults[] =
     // MCE_GCONF_USE_LOW_POWER_MODE_PATH @ modules/display.h
     .key  = "/system/osso/dsm/display/use_low_power_mode",
     .type = "b",
-    .def  = "false",
+    .def  = "true",
   },
   {
     // MCE_GCONF_TK_AUTOLOCK_ENABLED_PATH @ tklock.h


### PR DESCRIPTION
The settings ui will provide a way for users to opt out.

[mce] Enable use_low_power_mode setting by default. Fixes JB#19484
