### PR TITLE
Package legacy configuration items separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,6 +446,7 @@ install:: build
 	$(INSTALL_DTA) inifiles/hybris-led.ini $(DESTDIR)$(CONFDIR)/20hybris-led.ini
 	$(INSTALL_DTA) inifiles/debug-led.ini $(DESTDIR)$(CONFDIR)/20debug-led.ini
 	$(INSTALL_DTA) inifiles/als-defaults.ini $(DESTDIR)$(CONFDIR)/20als-defaults.ini
+	$(INSTALL_DTA) inifiles/legacy.ini $(DESTDIR)$(CONFDIR)/11legacy.ini
 
 ifeq ($(ENABLE_SYSTEMD_SUPPORT),y)
 install:: install_systemd_support

--- a/inifiles/als-defaults.ini
+++ b/inifiles/als-defaults.ini
@@ -1,3 +1,5 @@
+# Configuration file for MCE - Automatic display/led/keypad brightness control
+#
 # Configuration for tuning lisplay backlight, keypad backlight and indication led
 # brightness base on data from Ambient Light Sensor
 #
@@ -80,7 +82,6 @@ LevelsProfile0=6;8;9;11;12;13;15;16;18;19;20;28;36;44;52;60;68;76;84;92;100
 
 LimitsProfile0=1;2;3;6;11;20;36;66;121;220;489;599;732;896;1095;1340;1639;2005;2453;3000
 LevelsProfile0=30;33;36;39;42;45;48;51;54;57;64;68;72;76;80;84;88;92;96;100
-
 
 [BrightnessLPM]
 

--- a/inifiles/custom-led.ini
+++ b/inifiles/custom-led.ini
@@ -1,3 +1,5 @@
+# Configuration file for MCE - Example led patterns for hybris backend
+
 [LEDPatternHybris]
 # Patterns used for the hybris hardware;
 # Please prefix pattern names with Pattern to avoid name space clashes
@@ -27,4 +29,3 @@ PatternWhite=37;3;0;500;4000;ffffff
 #LEDPatternsRequired=PatternBlack
 # A list of pattern names that should not be used even if configured
 #LEDPatternsDisabled=PatternWhite
-

--- a/inifiles/debug-led.ini
+++ b/inifiles/debug-led.ini
@@ -1,3 +1,5 @@
+# Configuration file for MCE - Debug/panic led patterns for hybris backend
+
 [LEDPatternHybris]
 
 # Patterns used for the hybris hardware;

--- a/inifiles/hybris-led.ini
+++ b/inifiles/hybris-led.ini
@@ -1,3 +1,5 @@
+# Configuration file for MCE - Normal led patterns for hybris backend
+
 [LEDPatternHybris]
 
 # Patterns used for the hybris hardware;

--- a/inifiles/legacy.ini
+++ b/inifiles/legacy.ini
@@ -1,0 +1,398 @@
+# Configuration file for MCE - Unused/legacy items
+
+[TKLock]
+
+# Unlock the tklock if the camera is popped out
+#
+# 1 to enable, 0 to disable
+CameraPopoutUnlock=1
+
+[ALS]
+
+# Policy for brightness level step-downs
+#
+# direct - Switch to next brightness level immediately
+# unblank - Only step down the brightness after a blank->unblank cycle
+StepDownPolicy=direct
+
+[LEDPatternMonoRX34]
+
+# Patterns used for the RX-34 hardware;
+# this hardware has a single-colour LED without a dedicated engine
+# Please prefix pattern names with Pattern to avoid name space clashes
+#
+# Note: For power management purposes, remember to keep try to keep the
+#       onPeriod relatively short (not shorter than 50ms though),
+#       the offPeriod long; if this is not possible, make sure to have
+#       a timeout for the pattern so that it goes off after 15-30 seconds
+#
+# Priority (0 - highest, 255 - lowest)
+# ScreenOn - 0 only show pattern when the display is off
+#            1 show pattern even when the display is on
+#            2 only show pattern when the display is off, including acting dead
+#            3 show pattern even when the display is on, including acting dead
+#            4 only show pattern if the display is off, or if in acting dead
+#            5 always show pattern, even if LED disabled
+# Timeout in seconds before pattern is disabled, 0 for infinite
+# OnPeriod time in milliseconds
+# OffPeriod time in milliseconds
+#      (0 for continuous light; ONLY when the charger is connected!)
+# Intensity in steps from 0 (off) to 15 (full intensity)
+PatternDeviceOn=254;0;0;75;5000;10
+PatternDeviceSoftOff=253;0;0;100;10000;5
+PatternPowerOn=9;3;0;2000;1000;15
+PatternPowerOff=10;3;0;2000;1000;15
+PatternCommunication=30;1;0;250;2000;15
+PatternCommunicationCall=30;1;0;250;2000;15
+PatternCommunicationIM=30;1;0;250;2000;15
+PatternCommunicationSMS=30;1;0;250;2000;15
+PatternCommunicationEmail=30;1;0;250;2000;15
+PatternCommonNotification=30;1;0;250;2000;15
+PatternWebcamActive=255;0;0;0;0;0
+PatternBatteryCharging=50;4;0;500;7500;10
+PatternBatteryFull=40;4;0;1500;0;10
+
+# This example pattern has a priority of 42 (all patterns with a *lower*
+# priority value will have precedence), an on-period of 0.5 seconds,
+# and an off-period of 1.5 seconds.  The pattern will be active for
+# 30 seconds, then stop.  The brightness level will be 10 (with 15 being
+# the maximum, this would amount to 66%.
+# This pattern will be visible even when the display is on.
+PatternExample=42;1;30;500;1500;10
+
+[LEDPatternNJoyRX44]
+
+# Patterns used for the RX-44 hardware;
+# this hardware has an RGB LED connected to a NJoy controller
+# Please prefix pattern names with Pattern to avoid name space clashes
+#
+# Priority (0 - highest, 255 - lowest)
+# ScreenOn - 0 only show pattern when the display is off
+#            1 show pattern even when the display is on
+#            2 only show pattern when the display is off, including acting dead
+#            3 show pattern even when the display is on, including acting dead
+#            4 only show pattern if the display is off, or if in acting dead
+#            5 always show pattern, even if LED disabled
+# Timeout in seconds before pattern is disabled, 0 for infinite
+# R-channel pattern in NJoy format (16 commands at most)
+# G-channel pattern in NJoy format (16 commands at most)
+# B-channel pattern in NJoy format (16 commands at most)
+#
+# 0000 -- Jump to the start of the pattern for the channel
+# 40xx -- Set channel brightness
+# xxyy -- Increment/decrement
+#      xx determines the speed;
+#         01-3f -- short step time (granularity 0.49ms)
+#         41-7f -- long step time (granularity 15.6ms)
+#      yy determines the increment/decrement steps
+#         00-7f -- increment steps 00 = 0 steps, 7f = 127 steps
+#         80-ff -- decrement steps 80 = 0 steps, ff = 127 steps
+#
+#         Use 0 steps to create pauses
+#         Two consecutive increment/decrement sequences are needed
+#         to cover the entire range from 0-255
+# c000 -- End pattern execution
+# e002 -- Send red trigger
+# e004 -- Send green trigger
+# e008 -- Send blue trigger
+# e080 -- Wait for red trigger
+# e100 -- Wait for green trigger
+# e200 -- Wait for blue trigger
+PatternDeviceOn=254;0;0;4000205f20df7f007f007f007f000000;4000205f20df7f007f007f007f000000;4000205f20df7f007f007f007f000000
+PatternDeviceSoftOff=253;0;0;4000203f20bf7f007f007f007f007f000000;4000203f20bf7f007f007f007f007f000000;0000
+PatternPowerOn=9;3;0;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000
+PatternPowerOff=10;3;0;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000
+PatternCommunication=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommunicationCall=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommunicationIM=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommunicationSMS=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommunicationEmail=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommonNotification=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternWebcamActive=20;1;0;4000027f027fc000;0000;0000
+PatternBatteryCharging=50;4;0;0000;4000257f06ff7f0041000000;0000
+PatternBatteryFull=40;4;0;0000;407f0000;0000
+
+# This example pattern has a priority of 42 (all patterns with a *lower*
+# priority value will have precedence), and will flash in yellow
+# This pattern will be visible even when the display is on.
+PatternExample=42;1;30;4000167f167f17ff17ff0000;4000167f167f17ff17ff0000;0000
+
+[LEDPatternNJoyRX48]
+
+# Patterns used for the RX-48 hardware;
+# this hardware has an RGB LED connected to a NJoy controller
+# Please prefix pattern names with Pattern to avoid name space clashes
+#
+# Priority (0 - highest, 255 - lowest)
+# ScreenOn - 0 only show pattern when the display is off
+#            1 show pattern even when the display is on
+#            2 only show pattern when the display is off, including acting dead
+#            3 show pattern even when the display is on, including acting dead
+#            4 only show pattern if the display is off, or if in acting dead
+#            5 always show pattern, even if LED disabled
+# Timeout in seconds before pattern is disabled, 0 for infinite
+# R-channel pattern in NJoy format (16 commands at most)
+# G-channel pattern in NJoy format (16 commands at most)
+# B-channel pattern in NJoy format (16 commands at most)
+#
+# 0000 -- Jump to the start of the pattern for the channel
+# 40xx -- Set channel brightness
+# xxyy -- Increment/decrement
+#      xx determines the speed;
+#         01-3f -- short step time (granularity 0.49ms)
+#         41-7f -- long step time (granularity 15.6ms)
+#      yy determines the increment/decrement steps
+#         00-7f -- increment steps 00 = 0 steps, 7f = 127 steps
+#         80-ff -- decrement steps 80 = 0 steps, ff = 127 steps
+#
+#         Use 0 steps to create pauses
+#         Two consecutive increment/decrement sequences are needed
+#         to cover the entire range from 0-255
+# c000 -- End pattern execution
+# e002 -- Send red trigger
+# e004 -- Send green trigger
+# e008 -- Send blue trigger
+# e080 -- Wait for red trigger
+# e100 -- Wait for green trigger
+# e200 -- Wait for blue trigger
+PatternDeviceOn=254;0;0;4000e100207e207ee00420fe20fee0047f007f007f007f000000;4000e0024a15e0804a95e0807f007f007f007f000000;0000
+PatternDeviceSoftOff=253;0;0;4000204f20cf7f007f007f007f007f000000;4000204f20cf7f007f007f007f007f000000;0000
+PatternPowerOn=9;3;0;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000
+PatternPowerOff=10;3;0;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000
+PatternCommunication=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommunicationCall=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommunicationIM=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommunicationSMS=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommunicationEmail=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternCommonNotification=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
+PatternWebcamActive=20;1;0;4000027f027fc000;0000;0000
+PatternBatteryCharging=50;4;0;0000;4000257f06ff7f0041000000;0000
+PatternBatteryFull=40;4;0;0000;407f0000;0000
+
+# This example pattern has a priority of 42 (all patterns with a *lower*
+# priority value will have precedence), and will flash in yellow
+# This pattern will be visible even when the display is on.
+PatternExample=42;1;30;4000167f167f17ff17ff0000;4000167f167f17ff17ff0000;0000
+
+[LEDPatternLystiRX51]
+
+# Patterns used for the RX-51 hardware;
+# this hardware has an RGB LED connected to a Lysti controller
+# Please prefix pattern names with Pattern to avoid name space clashes
+#
+# Priority (0 - highest, 255 - lowest)
+# ScreenOn - 0 only show pattern when the display is off
+#            1 show pattern even when the display is on
+#            2 only show pattern when the display is off, including acting dead
+#            3 show pattern even when the display is on, including acting dead
+#            4 only show pattern if the display is off, or if in acting dead
+#            5 always show pattern, even if LED disabled
+# Timeout in seconds before pattern is disabled, 0 for infinite
+# LED(s) to map to Engine 1/Engine 2
+#         "r", "g", "b" maps the LED to engine 1
+#         "R", "G", "B" maps the LED to engine 2
+#         Example:
+#            "rG" maps the red LED to engine 1,
+#                      the green LED to engine 2,
+#                      and leaves the blue LED unmapped
+#         Avoid mapping the same LEDs to both engines...
+# Engine 1 pattern in Lysti format (16 commands at most)
+# Engine 2 pattern in Lysti format (16 commands at most)
+#
+# 0000 -- Jump to the start of the pattern for the channel
+# 40xx -- Set channel brightness
+# 9d80 -- Refresh Mux (use as first command in every pattern!)
+# xxyy -- Increment/decrement
+#      xx determines the speed;
+#         02-3f -- short step time (granularity 0.49ms)
+#         42-7f -- long step time (granularity 15.6ms)
+#
+#         If xx is even, increment
+#         If xx is odd, decrement
+#      yy determines the increment/decrement steps
+#         00-ff -- in/decrement steps
+#
+#         Use 0 steps to create pauses
+# c000 -- End pattern execution
+# e002 -- Send engine 1 trigger
+# e004 -- Send engine 2 trigger
+# e008 -- Send engine 3 trigger <used by key backlight!>
+# e080 -- Wait for engine 1 trigger
+# e100 -- Wait for engine 2 trigger
+# e200 -- Wait for engine 3 trigger <used by key backlight!>
+PatternDeviceOn=254;0;0;rgb;9d804000422043207f100000;9d800000
+PatternDeviceSoftOff=253;0;0;rg;9d804000423f433f7f100000;9d800000
+PatternPowerOn=9;3;0;rgb;9d80400042ff02ffc000;9d800000
+PatternPowerOff=10;3;0;rgb;9d80400001ff43ff7f007f00c000;9d800000
+PatternCommunication=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
+PatternCommunicationCall=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
+PatternCommunicationIM=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
+PatternCommunicationSMS=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
+PatternCommunicationEmail=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
+PatternCommonNotification=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
+PatternWebcamActive=20;1;0;r;9d80400004ffc0000000;9d800000
+PatternBatteryCharging=50;4;0;rg;9d804000427f0d7f7f007f0042000000;9d800000
+PatternBatteryFull=40;4;0;g;9d80407f0000;9d800000
+
+# This example pattern has a priority of 42 (all patterns with a *lower*
+# priority value will have precedence), and will flash in yellow
+# This pattern will be visible even when the display is on.
+PatternExample=42;1;30;rg;9d80400044ff45ff0000;9d800000
+
+[LEDPatternLystiRM680]
+
+# Patterns used for the RM-680/RM-690 hardware;
+# this hardware has a single-colour LED connected to a Lysti controller
+# Please prefix pattern names with Pattern to avoid name space clashes
+#
+# Priority (0 - highest, 255 - lowest)
+# ScreenOn - 0 only show pattern when the display is off
+#            1 show pattern even when the display is on
+#            2 only show pattern when the display is off, including acting dead
+#            3 show pattern even when the display is on, including acting dead
+#            4 only show pattern if the display is off, or if in acting dead
+#            5 always show pattern, even if LED disabled
+# Timeout in seconds before pattern is disabled, 0 for infinite
+# Pattern in Lysti format (16 commands at most)
+#
+# 0000 -- Jump to the start of the pattern for the channel
+# 40xx -- Set channel brightness
+# 9d80 -- Refresh Mux (use as first command in every pattern!)
+# xxyy -- Increment/decrement
+#      xx determines the speed;
+#         02-3f -- short step time (granularity 0.49ms)
+#         42-7f -- long step time (granularity 15.6ms)
+#
+#         If xx is even, increment
+#         If xx is odd, decrement
+#      yy determines the increment/decrement steps
+#         00-ff -- in/decrement steps
+#
+#         Use 0 steps to create pauses
+# c000 -- End pattern execution
+
+# FIXME: sloooooow breathing
+PatternDeviceSoftOff=253;0;0;9d804000423f433f7f100000
+
+PatternPowerOn=9;3;0;9d80400012ff03ffc000
+PatternPowerOff=10;3;0;9d80400002ff1bffc000
+PatternCommunication=30;1;0;9d80400004ff05ff04ff05ff437f0000
+PatternBatteryCharging=50;4;0;9d804000427f437f433f0000
+PatternBatteryChargingFlat=50;4;0;9d80407f7f007f007f007f004000437f0000
+PatternBatteryFull=40;4;0;9d80407f0000
+
+# Patterns only for use by combination rules
+PatternCommunicationAndBatteryFull=29;1;0;9d8040ff05ff04ff05ff04ff42bf0000
+
+# A combination-rule describes pattern transformations
+# Please prefix combination-rule names with Combination
+# to avoid name space clashes
+#
+# The first entry is the name of the pattern that holds the combined
+# pattern; the following entries are the pre-requisites
+# If all pre-requisites are true, then the combination pattern
+# is activated
+#
+# Note: Ensure that the combination pattern always has a higher priority
+# than the highest priority component
+CombinationCommunicationAndBatteryFull=PatternCommunicationAndBatteryFull;PatternCommunication;PatternBatteryFull
+
+# This example pattern has a priority of 42 (all patterns with a *lower*
+# priority value will have precedence), and will flash
+# This pattern will be visible even when the display is on.
+PatternExample=42;1;30;9d80400044ff45ff0000
+
+[LEDPatternNJoyRM696]
+
+# Patterns used for the RM-696 hardware;
+# this hardware has a single-colour LED connected to a NJoy controller
+# Please prefix pattern names with Pattern to avoid name space clashes
+#
+# Priority (0 - highest, 255 - lowest)
+# ScreenOn - 0 only show pattern when the display is off
+#            1 show pattern even when the display is on
+#            2 only show pattern when the display is off, including acting dead
+#            3 show pattern even when the display is on, including acting dead
+#            4 only show pattern if the display is off, or if in acting dead
+#            5 always show pattern, even if LED disabled
+# Timeout in seconds before pattern is disabled, 0 for infinite
+# Pattern in NJoy format (16 commands at most)
+#
+# 0000 -- Jump to the start of the pattern for the channel
+# 40xx -- Set channel brightness
+# xxyy -- Increment/decrement
+#      xx determines the speed;
+#         01-3f -- short step time (granularity 0.49ms)
+#         41-7f -- long step time (granularity 15.6ms)
+#      yy determines the increment/decrement steps
+#         00-7f -- increment steps 00 = 0 steps, 7f = 127 steps
+#         80-ff -- decrement steps 80 = 0 steps, ff = 127 steps
+#
+#         Use 0 steps to create pauses
+#         Two consecutive increment/decrement sequences are needed
+#         to cover the entire range from 0-255
+# c000 -- End pattern execution
+
+# FIXME: sloooooow breathing
+PatternDeviceSoftOff=253;0;0;4000413f41bf5f900000
+
+PatternPowerOn=9;3;0;4000087f087f01ff01ffc000
+PatternPowerOff=10;3;0;4000017f017fc000
+PatternCommunication=30;1;0;4000027f027f02ff02ff027f027f02ff02ff41ff0000
+PatternBatteryCharging=50;4;0;4000417f41ff41bf0000
+PatternBatteryChargingFlat=50;4;0;407f5f005f005f005f00400041ff0000
+PatternBatteryFull=40;4;0;407f0000
+
+# Patterns only for use by combination rules
+PatternCommunicationAndBatteryFull=29;1;0;40ff02ff02ff027f027f02ff02ff027f027f417f413f0000
+
+# A combination-rule describes pattern transformations
+# Please prefix combination-rule names with Combination
+# to avoid name space clashes
+#
+# The first entry is the name of the pattern that holds the combined
+# pattern; the following entries are the pre-requisites
+# If all pre-requisites are true, then the combination pattern
+# is activated
+#
+# Note: Ensure that the combination pattern always has a higher priority
+# than the highest priority component
+CombinationCommunicationAndBatteryFull=PatternCommunicationAndBatteryFull;PatternCommunication;PatternBatteryFull
+
+# This example pattern has a priority of 42 (all patterns with a *lower*
+# priority value will have precedence), and will flash
+# This pattern will be visible even when the display is on.
+PatternExample=42;1;30;4000427f427f42ff42ff0000
+
+[Display-c1]
+
+# Color phase adjustments for the c1.* display revision
+# Each value consists of sets of 12 numbers, each forming a entry for certain
+# brightness range, the sets contain, brightness values in lux*3.3
+# (330 = 100 lux):
+#  - brightness range lower limit (one of the ranges should start from 0)
+#  - brightness range upper limit (one of the ranges should have -1 = unlimited)
+#  - high brightness mode level
+#  - 3 coefficients for output red channel (red, green, blue)
+#  - 3 coefficients for output green channel (red, green, blue)
+#  - 3 coefficients for output blue channel (red, green, blue)
+
+Neutral=0;330;0;195;48;13;22;206;28;8;8;240;330;9900;0;195;48;13;22;206;28;8;8;240
+Vivid=0;33000;0;255;0;0;0;255;0;0;0;255;33000;-1;0;275;-10;-10;-10;275;-10;-10;-10;275;33000;-1;1;295;-20;-20;-20;295;-20;-20;-20;295;33000;-10;2;315;-30;-30;-30;315;-30;-30;-30;315
+Muted=0;-1;0;156;79;21;40;165;51;32;32;192
+
+[Display-fe]
+
+# Color phase adjustments for the fe.* display revision
+# See above for details
+
+Neutral=0;330;0;199;28;28;8;209;38;8;8;239;330;9900;0;199;28;28;8;209;38;8;8;239
+Vivid=0;33000;0;255;0;0;0;255;0;0;0;255;33000;-1;0;275;-10;-10;-10;275;-10;-10;-10;275;33000;-1;1;295;-20;-20;-20;295;-20;-20;-20;295;33000;-10;2;315;-30;-30;-30;315;-30;-30;-30;315
+Muted=0;-1;0;159;48;48;15;167;73;32;32;191
+
+[RadioStates]MasterRadioState
+[RadioStates]CellularRadioState
+[RadioStates]WLANRadioState
+[RadioStates]BluetoothRadioState
+[RadioStates]NFCRadioState
+[RadioStates]FMTXRadioState

--- a/inifiles/mce-radio-states.ini
+++ b/inifiles/mce-radio-states.ini
@@ -1,3 +1,5 @@
+# Configuration file for MCE - Radio state defaults to use on the 1st boot
+
 [RadioStates]
 MasterRadioState=true
 CellularRadioState=true

--- a/inifiles/mce.ini
+++ b/inifiles/mce.ini
@@ -18,7 +18,6 @@ ModulePath=/usr/lib/mce/modules
 # Note: the name should not include the "lib"-prefix
 Modules=radiostates;filter-brightness-als;display;keypad;led;battery-upower;inactivity;alarm;callstate;audiorouting;proximity;powersavemode;cpu-keepalive;doubletap;packagekit;sensor-gestures;bluetooth;
 
-
 [HomeKey]
 
 # Try to make this possible somehow
@@ -29,7 +28,6 @@ Modules=radiostates;filter-brightness-als;display;keypad;led;battery-upower;inac
 #
 # Timeout in milliseconds, default 800
 HomeKeyLongDelay=800
-
 
 [PowerKey]
 
@@ -96,7 +94,6 @@ PowerKeyLongAction=poweroff
 # PowerKeyDoubleAction=dbus-signal-powerkey_double_ind
 PowerKeyDoubleAction=disabled
 
-
 [SoftPowerOff]
 
 # Charger connect policy
@@ -105,7 +102,6 @@ PowerKeyDoubleAction=disabled
 # wakeup - wake up from soft poweroff when a charger is connected
 # ignore - remain in soft poweroff when a charger is connected
 ChargerPolicyConnect=ignore
-
 
 [TKLock]
 
@@ -163,11 +159,6 @@ ProximityLockWhenSlideOpen=0
 #     before opening the slide and there has been no input
 AlwaysLockOnSlideClose=0
 
-# Unlock the tklock if the camera is popped out
-#
-# 1 to enable, 0 to disable
-CameraPopoutUnlock=1
-
 # Unlock the tklock if the lens cover is opened
 #
 # 1 to enable, 0 to disable
@@ -178,7 +169,6 @@ LensCoverUnlock=1
 #
 # 1 to enable, 0 to disable
 TriggerUnlockScreenWithVolumeKeys=0
-
 
 [KeyPad]
 
@@ -200,7 +190,6 @@ BacklightFadeInTime=250
 #                          valid values: 0, 125, 250, 375, 500
 #                                           625, 750, 875, 1000
 BacklightFadeOutTime=1000
-
 
 [Display]
 
@@ -248,16 +237,6 @@ StepTimeDecrease=10
 #                           valid values: 2000-5000
 ConstantTimeDecrease=3000
 
-
-[ALS]
-
-# Policy for brightness level step-downs
-#
-# direct - Switch to next brightness level immediately
-# unblank - Only step down the brightness after a blank->unblank cycle
-StepDownPolicy=direct
-
-
 [LED]
 
 # A list of all pattern names that should be configured
@@ -265,384 +244,3 @@ LEDPatternsRequired=PatternPowerOn;PatternPowerOff;PatternCommunication;PatternC
 CombinationRules=CombinationCommunicationAndBatteryFull
 # A list of pattern names that should not be used even if configured
 LEDPatternsDisabled=
-
-
-[LEDPatternMonoRX34]
-
-# Patterns used for the RX-34 hardware;
-# this hardware has a single-colour LED without a dedicated engine
-# Please prefix pattern names with Pattern to avoid name space clashes
-#
-# Note: For power management purposes, remember to keep try to keep the
-#       onPeriod relatively short (not shorter than 50ms though),
-#       the offPeriod long; if this is not possible, make sure to have
-#       a timeout for the pattern so that it goes off after 15-30 seconds
-#
-# Priority (0 - highest, 255 - lowest)
-# ScreenOn - 0 only show pattern when the display is off
-#            1 show pattern even when the display is on
-#            2 only show pattern when the display is off, including acting dead
-#            3 show pattern even when the display is on, including acting dead
-#            4 only show pattern if the display is off, or if in acting dead
-#            5 always show pattern, even if LED disabled
-# Timeout in seconds before pattern is disabled, 0 for infinite
-# OnPeriod time in milliseconds
-# OffPeriod time in milliseconds
-#      (0 for continuous light; ONLY when the charger is connected!)
-# Intensity in steps from 0 (off) to 15 (full intensity)
-PatternDeviceOn=254;0;0;75;5000;10
-PatternDeviceSoftOff=253;0;0;100;10000;5
-PatternPowerOn=9;3;0;2000;1000;15
-PatternPowerOff=10;3;0;2000;1000;15
-PatternCommunication=30;1;0;250;2000;15
-PatternCommunicationCall=30;1;0;250;2000;15
-PatternCommunicationIM=30;1;0;250;2000;15
-PatternCommunicationSMS=30;1;0;250;2000;15
-PatternCommunicationEmail=30;1;0;250;2000;15
-PatternCommonNotification=30;1;0;250;2000;15
-PatternWebcamActive=255;0;0;0;0;0
-PatternBatteryCharging=50;4;0;500;7500;10
-PatternBatteryFull=40;4;0;1500;0;10
-
-# This example pattern has a priority of 42 (all patterns with a *lower*
-# priority value will have precedence), an on-period of 0.5 seconds,
-# and an off-period of 1.5 seconds.  The pattern will be active for
-# 30 seconds, then stop.  The brightness level will be 10 (with 15 being
-# the maximum, this would amount to 66%.
-# This pattern will be visible even when the display is on.
-PatternExample=42;1;30;500;1500;10
-
-
-[LEDPatternNJoyRX44]
-
-# Patterns used for the RX-44 hardware;
-# this hardware has an RGB LED connected to a NJoy controller
-# Please prefix pattern names with Pattern to avoid name space clashes
-#
-# Priority (0 - highest, 255 - lowest)
-# ScreenOn - 0 only show pattern when the display is off
-#            1 show pattern even when the display is on
-#            2 only show pattern when the display is off, including acting dead
-#            3 show pattern even when the display is on, including acting dead
-#            4 only show pattern if the display is off, or if in acting dead
-#            5 always show pattern, even if LED disabled
-# Timeout in seconds before pattern is disabled, 0 for infinite
-# R-channel pattern in NJoy format (16 commands at most)
-# G-channel pattern in NJoy format (16 commands at most)
-# B-channel pattern in NJoy format (16 commands at most)
-#
-# 0000 -- Jump to the start of the pattern for the channel
-# 40xx -- Set channel brightness
-# xxyy -- Increment/decrement
-#      xx determines the speed;
-#         01-3f -- short step time (granularity 0.49ms)
-#         41-7f -- long step time (granularity 15.6ms)
-#      yy determines the increment/decrement steps
-#         00-7f -- increment steps 00 = 0 steps, 7f = 127 steps
-#         80-ff -- decrement steps 80 = 0 steps, ff = 127 steps
-#
-#         Use 0 steps to create pauses
-#         Two consecutive increment/decrement sequences are needed
-#         to cover the entire range from 0-255
-# c000 -- End pattern execution
-# e002 -- Send red trigger
-# e004 -- Send green trigger
-# e008 -- Send blue trigger
-# e080 -- Wait for red trigger
-# e100 -- Wait for green trigger
-# e200 -- Wait for blue trigger
-PatternDeviceOn=254;0;0;4000205f20df7f007f007f007f000000;4000205f20df7f007f007f007f000000;4000205f20df7f007f007f007f000000
-PatternDeviceSoftOff=253;0;0;4000203f20bf7f007f007f007f007f000000;4000203f20bf7f007f007f007f007f000000;0000
-PatternPowerOn=9;3;0;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000
-PatternPowerOff=10;3;0;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000
-PatternCommunication=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommunicationCall=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommunicationIM=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommunicationSMS=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommunicationEmail=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommonNotification=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternWebcamActive=20;1;0;4000027f027fc000;0000;0000
-PatternBatteryCharging=50;4;0;0000;4000257f06ff7f0041000000;0000
-PatternBatteryFull=40;4;0;0000;407f0000;0000
-
-# This example pattern has a priority of 42 (all patterns with a *lower*
-# priority value will have precedence), and will flash in yellow
-# This pattern will be visible even when the display is on.
-PatternExample=42;1;30;4000167f167f17ff17ff0000;4000167f167f17ff17ff0000;0000
-
-
-[LEDPatternNJoyRX48]
-
-# Patterns used for the RX-48 hardware;
-# this hardware has an RGB LED connected to a NJoy controller
-# Please prefix pattern names with Pattern to avoid name space clashes
-#
-# Priority (0 - highest, 255 - lowest)
-# ScreenOn - 0 only show pattern when the display is off
-#            1 show pattern even when the display is on
-#            2 only show pattern when the display is off, including acting dead
-#            3 show pattern even when the display is on, including acting dead
-#            4 only show pattern if the display is off, or if in acting dead
-#            5 always show pattern, even if LED disabled
-# Timeout in seconds before pattern is disabled, 0 for infinite
-# R-channel pattern in NJoy format (16 commands at most)
-# G-channel pattern in NJoy format (16 commands at most)
-# B-channel pattern in NJoy format (16 commands at most)
-#
-# 0000 -- Jump to the start of the pattern for the channel
-# 40xx -- Set channel brightness
-# xxyy -- Increment/decrement
-#      xx determines the speed;
-#         01-3f -- short step time (granularity 0.49ms)
-#         41-7f -- long step time (granularity 15.6ms)
-#      yy determines the increment/decrement steps
-#         00-7f -- increment steps 00 = 0 steps, 7f = 127 steps
-#         80-ff -- decrement steps 80 = 0 steps, ff = 127 steps
-#
-#         Use 0 steps to create pauses
-#         Two consecutive increment/decrement sequences are needed
-#         to cover the entire range from 0-255
-# c000 -- End pattern execution
-# e002 -- Send red trigger
-# e004 -- Send green trigger
-# e008 -- Send blue trigger
-# e080 -- Wait for red trigger
-# e100 -- Wait for green trigger
-# e200 -- Wait for blue trigger
-PatternDeviceOn=254;0;0;4000e100207e207ee00420fe20fee0047f007f007f007f000000;4000e0024a15e0804a95e0807f007f007f007f000000;0000
-PatternDeviceSoftOff=253;0;0;4000204f20cf7f007f007f007f007f000000;4000204f20cf7f007f007f007f007f000000;0000
-PatternPowerOn=9;3;0;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000
-PatternPowerOff=10;3;0;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000
-PatternCommunication=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommunicationCall=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommunicationIM=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommunicationSMS=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommunicationEmail=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternCommonNotification=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
-PatternWebcamActive=20;1;0;4000027f027fc000;0000;0000
-PatternBatteryCharging=50;4;0;0000;4000257f06ff7f0041000000;0000
-PatternBatteryFull=40;4;0;0000;407f0000;0000
-
-# This example pattern has a priority of 42 (all patterns with a *lower*
-# priority value will have precedence), and will flash in yellow
-# This pattern will be visible even when the display is on.
-PatternExample=42;1;30;4000167f167f17ff17ff0000;4000167f167f17ff17ff0000;0000
-
-
-[LEDPatternLystiRX51]
-
-# Patterns used for the RX-51 hardware;
-# this hardware has an RGB LED connected to a Lysti controller
-# Please prefix pattern names with Pattern to avoid name space clashes
-#
-# Priority (0 - highest, 255 - lowest)
-# ScreenOn - 0 only show pattern when the display is off
-#            1 show pattern even when the display is on
-#            2 only show pattern when the display is off, including acting dead
-#            3 show pattern even when the display is on, including acting dead
-#            4 only show pattern if the display is off, or if in acting dead
-#            5 always show pattern, even if LED disabled
-# Timeout in seconds before pattern is disabled, 0 for infinite
-# LED(s) to map to Engine 1/Engine 2
-#         "r", "g", "b" maps the LED to engine 1
-#         "R", "G", "B" maps the LED to engine 2
-#         Example:
-#            "rG" maps the red LED to engine 1,
-#                      the green LED to engine 2,
-#		       and leaves the blue LED unmapped
-#         Avoid mapping the same LEDs to both engines...
-# Engine 1 pattern in Lysti format (16 commands at most)
-# Engine 2 pattern in Lysti format (16 commands at most)
-#
-# 0000 -- Jump to the start of the pattern for the channel
-# 40xx -- Set channel brightness
-# 9d80 -- Refresh Mux (use as first command in every pattern!)
-# xxyy -- Increment/decrement
-#      xx determines the speed;
-#         02-3f -- short step time (granularity 0.49ms)
-#         42-7f -- long step time (granularity 15.6ms)
-#
-#	  If xx is even, increment
-#         If xx is odd, decrement
-#      yy determines the increment/decrement steps
-#         00-ff -- in/decrement steps
-#
-#         Use 0 steps to create pauses
-# c000 -- End pattern execution
-# e002 -- Send engine 1 trigger
-# e004 -- Send engine 2 trigger
-# e008 -- Send engine 3 trigger <used by key backlight!>
-# e080 -- Wait for engine 1 trigger
-# e100 -- Wait for engine 2 trigger
-# e200 -- Wait for engine 3 trigger <used by key backlight!>
-PatternDeviceOn=254;0;0;rgb;9d804000422043207f100000;9d800000
-PatternDeviceSoftOff=253;0;0;rg;9d804000423f433f7f100000;9d800000
-PatternPowerOn=9;3;0;rgb;9d80400042ff02ffc000;9d800000
-PatternPowerOff=10;3;0;rgb;9d80400001ff43ff7f007f00c000;9d800000
-PatternCommunication=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
-PatternCommunicationCall=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
-PatternCommunicationIM=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
-PatternCommunicationSMS=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
-PatternCommunicationEmail=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
-PatternCommonNotification=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
-PatternWebcamActive=20;1;0;r;9d80400004ffc0000000;9d800000
-PatternBatteryCharging=50;4;0;rg;9d804000427f0d7f7f007f0042000000;9d800000
-PatternBatteryFull=40;4;0;g;9d80407f0000;9d800000
-
-# This example pattern has a priority of 42 (all patterns with a *lower*
-# priority value will have precedence), and will flash in yellow
-# This pattern will be visible even when the display is on.
-PatternExample=42;1;30;rg;9d80400044ff45ff0000;9d800000
-
-
-[LEDPatternLystiRM680]
-
-# Patterns used for the RM-680/RM-690 hardware;
-# this hardware has a single-colour LED connected to a Lysti controller
-# Please prefix pattern names with Pattern to avoid name space clashes
-#
-# Priority (0 - highest, 255 - lowest)
-# ScreenOn - 0 only show pattern when the display is off
-#            1 show pattern even when the display is on
-#            2 only show pattern when the display is off, including acting dead
-#            3 show pattern even when the display is on, including acting dead
-#            4 only show pattern if the display is off, or if in acting dead
-#            5 always show pattern, even if LED disabled
-# Timeout in seconds before pattern is disabled, 0 for infinite
-# Pattern in Lysti format (16 commands at most)
-#
-# 0000 -- Jump to the start of the pattern for the channel
-# 40xx -- Set channel brightness
-# 9d80 -- Refresh Mux (use as first command in every pattern!)
-# xxyy -- Increment/decrement
-#      xx determines the speed;
-#         02-3f -- short step time (granularity 0.49ms)
-#         42-7f -- long step time (granularity 15.6ms)
-#
-#	  If xx is even, increment
-#         If xx is odd, decrement
-#      yy determines the increment/decrement steps
-#         00-ff -- in/decrement steps
-#
-#         Use 0 steps to create pauses
-# c000 -- End pattern execution
-
-# FIXME: sloooooow breathing
-PatternDeviceSoftOff=253;0;0;9d804000423f433f7f100000
-
-PatternPowerOn=9;3;0;9d80400012ff03ffc000
-PatternPowerOff=10;3;0;9d80400002ff1bffc000
-PatternCommunication=30;1;0;9d80400004ff05ff04ff05ff437f0000
-PatternBatteryCharging=50;4;0;9d804000427f437f433f0000
-PatternBatteryChargingFlat=50;4;0;9d80407f7f007f007f007f004000437f0000
-PatternBatteryFull=40;4;0;9d80407f0000
-
-# Patterns only for use by combination rules
-PatternCommunicationAndBatteryFull=29;1;0;9d8040ff05ff04ff05ff04ff42bf0000
-
-# A combination-rule describes pattern transformations
-# Please prefix combination-rule names with Combination
-# to avoid name space clashes
-#
-# The first entry is the name of the pattern that holds the combined
-# pattern; the following entries are the pre-requisites
-# If all pre-requisites are true, then the combination pattern
-# is activated
-#
-# Note: Ensure that the combination pattern always has a higher priority
-# than the highest priority component
-CombinationCommunicationAndBatteryFull=PatternCommunicationAndBatteryFull;PatternCommunication;PatternBatteryFull
-
-# This example pattern has a priority of 42 (all patterns with a *lower*
-# priority value will have precedence), and will flash
-# This pattern will be visible even when the display is on.
-PatternExample=42;1;30;9d80400044ff45ff0000
-
-
-[LEDPatternNJoyRM696]
-
-# Patterns used for the RM-696 hardware;
-# this hardware has a single-colour LED connected to a NJoy controller
-# Please prefix pattern names with Pattern to avoid name space clashes
-#
-# Priority (0 - highest, 255 - lowest)
-# ScreenOn - 0 only show pattern when the display is off
-#            1 show pattern even when the display is on
-#            2 only show pattern when the display is off, including acting dead
-#            3 show pattern even when the display is on, including acting dead
-#            4 only show pattern if the display is off, or if in acting dead
-#            5 always show pattern, even if LED disabled
-# Timeout in seconds before pattern is disabled, 0 for infinite
-# Pattern in NJoy format (16 commands at most)
-#
-# 0000 -- Jump to the start of the pattern for the channel
-# 40xx -- Set channel brightness
-# xxyy -- Increment/decrement
-#      xx determines the speed;
-#         01-3f -- short step time (granularity 0.49ms)
-#         41-7f -- long step time (granularity 15.6ms)
-#      yy determines the increment/decrement steps
-#         00-7f -- increment steps 00 = 0 steps, 7f = 127 steps
-#         80-ff -- decrement steps 80 = 0 steps, ff = 127 steps
-#
-#         Use 0 steps to create pauses
-#         Two consecutive increment/decrement sequences are needed
-#         to cover the entire range from 0-255
-# c000 -- End pattern execution
-
-# FIXME: sloooooow breathing
-PatternDeviceSoftOff=253;0;0;4000413f41bf5f900000
-
-PatternPowerOn=9;3;0;4000087f087f01ff01ffc000
-PatternPowerOff=10;3;0;4000017f017fc000
-PatternCommunication=30;1;0;4000027f027f02ff02ff027f027f02ff02ff41ff0000
-PatternBatteryCharging=50;4;0;4000417f41ff41bf0000
-PatternBatteryChargingFlat=50;4;0;407f5f005f005f005f00400041ff0000
-PatternBatteryFull=40;4;0;407f0000
-
-# Patterns only for use by combination rules
-PatternCommunicationAndBatteryFull=29;1;0;40ff02ff02ff027f027f02ff02ff027f027f417f413f0000
-
-# A combination-rule describes pattern transformations
-# Please prefix combination-rule names with Combination
-# to avoid name space clashes
-#
-# The first entry is the name of the pattern that holds the combined
-# pattern; the following entries are the pre-requisites
-# If all pre-requisites are true, then the combination pattern
-# is activated
-#
-# Note: Ensure that the combination pattern always has a higher priority
-# than the highest priority component
-CombinationCommunicationAndBatteryFull=PatternCommunicationAndBatteryFull;PatternCommunication;PatternBatteryFull
-
-# This example pattern has a priority of 42 (all patterns with a *lower*
-# priority value will have precedence), and will flash
-# This pattern will be visible even when the display is on.
-PatternExample=42;1;30;4000427f427f42ff42ff0000
-
-[Display-c1]
-
-# Color phase adjustments for the c1.* display revision
-# Each value consists of sets of 12 numbers, each forming a entry for certain
-# brightness range, the sets contain, brightness values in lux*3.3
-# (330 = 100 lux):
-#  - brightness range lower limit (one of the ranges should start from 0)
-#  - brightness range upper limit (one of the ranges should have -1 = unlimited)
-#  - high brightness mode level
-#  - 3 coefficients for output red channel (red, green, blue)
-#  - 3 coefficients for output green channel (red, green, blue)
-#  - 3 coefficients for output blue channel (red, green, blue)
-
-Neutral=0;330;0;195;48;13;22;206;28;8;8;240;330;9900;0;195;48;13;22;206;28;8;8;240
-Vivid=0;33000;0;255;0;0;0;255;0;0;0;255;33000;-1;0;275;-10;-10;-10;275;-10;-10;-10;275;33000;-1;1;295;-20;-20;-20;295;-20;-20;-20;295;33000;-10;2;315;-30;-30;-30;315;-30;-30;-30;315
-Muted=0;-1;0;156;79;21;40;165;51;32;32;192
-
-[Display-fe]
-
-# Color phase adjustments for the fe.* display revision
-# See above for details
-
-Neutral=0;330;0;199;28;28;8;209;38;8;8;239;330;9900;0;199;28;28;8;209;38;8;8;239
-Vivid=0;33000;0;255;0;0;0;255;0;0;0;255;33000;-1;0;275;-10;-10;-10;275;-10;-10;-10;275;33000;-1;1;295;-20;-20;-20;295;-20;-20;-20;295;33000;-10;2;315;-30;-30;-30;315;-30;-30;-30;315
-Muted=0;-1;0;159;48;48;15;167;73;32;32;191

--- a/rpm/mce.spec
+++ b/rpm/mce.spec
@@ -51,6 +51,16 @@ Requires: glib2 >= 2.36.0
 %description tests
 This package contains test suite for mce
 
+%package config-legacy
+Summary:  Config files for mce (legacy hw)
+Group:    System/System Control
+
+%description config-legacy
+This package contains mce configuration files for legacy hw
+
+Potentially useful for using Nemomobile version of mce with
+Nokia N770, N800, N810, N900, N9 and N950 devices.
+
 %prep
 %setup -q -n %{name}-%{version}
 
@@ -112,3 +122,7 @@ systemctl daemon-reload || :
 %files tests
 %defattr(-,root,root,-)
 ## QUARANTINE /opt/tests/mce/*
+
+%files config-legacy
+%defattr(-,root,root,-)
+%config %{_sysconfdir}/%{name}/11legacy.ini


### PR DESCRIPTION
Move legacy configuration entries to separate file: legacy.ini.

Make them available via separate mce-config-legacy rpm package.

Also add one line description at the top of the each ini-file.

[mce] Package legacy configuration items separately. Fixes NEMO#616
