### PR TITLE
Do not use lpm display mode by default

### DIFF
--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1148,7 +1148,7 @@ static const setting_t gconf_defaults[] =
     // MCE_GCONF_USE_LOW_POWER_MODE @ modules/display.h
     .key  = "/system/osso/dsm/display/use_low_power_mode",
     .type = "b",
-    .def  = "true",
+    .def  = "false",
   },
   {
     // MCE_GCONF_TK_AUTOLOCK_ENABLED_PATH @ tklock.h


### PR DESCRIPTION
The use_low_power_mode setting now defaults to false.

[mce] Do not use lpm display mode by default. Contributes to JB#21920
