### PR TITLE
Allow user processes to query current memory level over D-Bus

### DIFF
--- a/mce.conf
+++ b/mce.conf
@@ -57,6 +57,10 @@
 		       send_interface="com.nokia.mce.request"
 		       send_member="get_color_profile"/>
 
+		<allow send_destination="com.nokia.mce"
+		       send_interface="com.nokia.mce.request"
+		       send_member="get_memory_level"/>
+
 		<!-- Tighten this policy -->
 		<allow send_destination="com.nokia.mce"
 		       send_interface="com.nokia.mce.request"


### PR DESCRIPTION
The get_memory_level method call was missing from mce dbus configuration
file and thus non-root processes could not query the current state.

Add dbus config entry for the get_memory_level method call and allow
non-root processes to make the query.
