### PR TITLE
Make touch input blocking by proximity sensor optional

### DIFF
--- a/.depend
+++ b/.depend
@@ -6,6 +6,7 @@ builtin-gconf.o:\
 	mce-log.h\
 	modules/memnotify.h\
 	powerkey.h\
+	tklock.h\
 
 builtin-gconf.pic.o:\
 	builtin-gconf.c\
@@ -15,6 +16,7 @@ builtin-gconf.pic.o:\
 	mce-log.h\
 	modules/memnotify.h\
 	powerkey.h\
+	tklock.h\
 
 datapipe.o:\
 	datapipe.c\

--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -23,6 +23,7 @@
 #include "mce-dbus.h"
 
 #include "powerkey.h"
+#include "tklock.h"
 
 #include "modules/memnotify.h"
 
@@ -1171,6 +1172,12 @@ static const setting_t gconf_defaults[] =
     .key  = "/system/osso/dsm/locks/lpm_triggering",
     .type = "i",
     .def  = "1", // = LPMUI_TRIGGERING_FROM_POCKET
+  },
+  {
+    // MCE_GCONF_PROXIMITY_BLOCKS_TOUCH @ tklock.h
+    .key  = "/system/osso/dsm/locks/proximity_blocks_touch",
+    .type = "b",
+    .def  = G_STRINGIFY(PROXIMITY_BLOCKS_TOUCH_DEFAULT),
   },
   {
     // MCE_GCONF_BLANKING_INHIBIT_MODE @ modules/display.h

--- a/tklock.c
+++ b/tklock.c
@@ -368,6 +368,11 @@ static gboolean tk_autolock_enabled = DEFAULT_TK_AUTOLOCK;
 /** GConf callback ID for tk_autolock_enabled */
 static guint tk_autolock_enabled_cb_id = 0;
 
+/** Flag: Proximity sensor can block touch input */
+static gboolean proximity_blocks_touch = PROXIMITY_BLOCKS_TOUCH_DEFAULT;
+/** GConf callback ID for proximity_blocks_touch */
+static guint proximity_blocks_touch_cb_id = 0;
+
 /** Touchscreen double tap gesture policy */
 static gint doubletap_gesture_policy = DBLTAP_ACTION_DEFAULT;
 /** GConf callback ID for doubletap_gesture_policy */
@@ -3432,8 +3437,11 @@ static void tklock_evctrl_rethink(void)
     }
 
     /* Grabbing touch input is always permitted, but ungrabbing
-     * only when proximity sensor is not covered */
-    if( grab_ts || proximity_state_effective == COVER_OPEN ) {
+     * only when proximity sensor is not covered / proximity
+     * blocks input feature is disabled */
+    if( grab_ts ||
+        !proximity_blocks_touch ||
+        proximity_state_effective == COVER_OPEN ) {
         execute_datapipe(&touch_grab_wanted_pipe,
                          GINT_TO_POINTER(grab_ts),
                          USE_INDATA, CACHE_INDATA);
@@ -3600,6 +3608,10 @@ static void tklock_gconf_cb(GConfClient *const gcc, const guint id,
         tk_autolock_enabled = gconf_value_get_bool(gcv) ? 1 : 0;
         tklock_autolock_rethink();
     }
+    else if( id == proximity_blocks_touch_cb_id ) {
+        proximity_blocks_touch = gconf_value_get_bool(gcv) ? 1 : 0;
+        tklock_evctrl_rethink();
+    }
     else if( id == doubletap_gesture_policy_cb_id ) {
         doubletap_gesture_policy = gconf_value_get_int(gcv);
         tklock_gconf_sanitize_doubletap_gesture_policy();
@@ -3696,6 +3708,14 @@ static void tklock_gconf_init(void)
                            &tklock_lpmui_triggering_cb_id);
 
     mce_gconf_get_int(MCE_GCONF_LPMUI_TRIGGERING, &tklock_lpmui_triggering);
+
+    /* Proximity can block touch input */
+    mce_gconf_notifier_add(MCE_GCONF_LOCK_PATH,
+                           MCE_GCONF_PROXIMITY_BLOCKS_TOUCH,
+                           tklock_gconf_cb,
+                           &proximity_blocks_touch_cb_id);
+    mce_gconf_get_bool(MCE_GCONF_PROXIMITY_BLOCKS_TOUCH,
+                       &proximity_blocks_touch);
 }
 
 /** Remove gconf change notifiers
@@ -3716,6 +3736,9 @@ static void tklock_gconf_quit(void)
 
     mce_gconf_notifier_remove(tklock_lpmui_triggering_cb_id),
         tklock_lpmui_triggering_cb_id = 0;
+
+    mce_gconf_notifier_remove(proximity_blocks_touch_cb_id),
+        proximity_blocks_touch_cb_id = 0;
 }
 
 /* ========================================================================= *

--- a/tklock.h
+++ b/tklock.h
@@ -99,6 +99,12 @@ typedef enum
 /** Automatic lpm triggering modes GConf setting */
 # define MCE_GCONF_LPMUI_TRIGGERING             MCE_GCONF_LOCK_PATH "/lpm_triggering"
 
+/** Proximity can block touch input GConf setting */
+# define MCE_GCONF_PROXIMITY_BLOCKS_TOUCH       MCE_GCONF_LOCK_PATH "/proximity_blocks_touch"
+
+/** Default value for can block touch input GConf setting */
+# define PROXIMITY_BLOCKS_TOUCH_DEFAULT         false
+
 /** Automatic lpm triggering modes */
 enum
 {

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -2418,6 +2418,29 @@ static void xmce_get_ps_mode(void)
         printf("%-"PAD1"s %s\n", "Use ps mode:", txt);
 }
 
+/** Set ps can block touch input mode
+ *
+ * @param args string suitable for interpreting as enabled/disabled
+ */
+static bool xmce_set_ps_blocks_touch(const char *args)
+{
+        gboolean val = xmce_parse_enabled(args);
+        mcetool_gconf_set_bool(MCE_GCONF_PROXIMITY_BLOCKS_TOUCH, val);
+        return true;
+}
+
+/** Get current ps can block touch input mode and print it out
+ */
+static void xmce_get_ps_blocks_touch(void)
+{
+        gboolean val = 0;
+        char txt[32] = "unknown";
+
+        if( mcetool_gconf_get_bool(MCE_GCONF_PROXIMITY_BLOCKS_TOUCH, &val) )
+                snprintf(txt, sizeof txt, "%s", val ? "enabled" : "disabled");
+        printf("%-"PAD1"s %s\n", "Touch can be blocked by ps:", txt);
+}
+
 /* ------------------------------------------------------------------------- *
  * als
  * ------------------------------------------------------------------------- */
@@ -3848,6 +3871,7 @@ static bool xmce_get_status(const char *args)
         xmce_get_lpmui_triggering();
         xmce_get_als_mode();
         xmce_get_ps_mode();
+        xmce_get_ps_blocks_touch();
         xmce_get_dim_timeouts();
         xmce_get_brightness_fade();
         xmce_get_suspend_policy();
@@ -4433,6 +4457,13 @@ static const mce_opt_t options[] =
                 .with_arg    = xmce_set_ps_mode,
                 .values      = "enabled|disabled",
                         "set the ps mode; valid modes are:\n"
+                        "'enabled' and 'disabled'\n"
+        },
+        {
+                .name        = "set-ps-blocks-touch",
+                .with_arg    = xmce_set_ps_blocks_touch,
+                .values      = "enabled|disabled",
+                        "allow ps to block touch input; valid modes are:\n"
                         "'enabled' and 'disabled'\n"
         },
         {


### PR DESCRIPTION
Many users have had problems with touch input immediately after bootup.
It is verly likely that it is caused by touch input getting blocked
by the proximity sensor. Since there is not yet visual clues about the
fact that it is happening, the users have no way of knowing what is
happening and how to remedy the situation.

Also porting projects where sensor adaptation is not fully working
have had trouble with this feature.

Add setting for enabling/disabling touch blocking by proximity sensor.

Disable the feature by default.

The default can be changed via:
  mcetool --set-ps-blocks-touch=<enabled|disabled>