### PR TITLE
Interpret BTN_TOUCH event with zero value as touch release

### DIFF
--- a/event-input.c
+++ b/event-input.c
@@ -1582,7 +1582,8 @@ evin_doubletap_emulate(const struct input_event *eve)
         break;
 
     case EV_KEY:
-        if( eve->code == BTN_MOUSE ) {
+        switch( eve->code ) {
+        case BTN_MOUSE:
             /* Store click/release and position */
             if( eve->value )
                 hist[i0].dt_click += SEEN_EVENT_MOUSE;
@@ -1591,6 +1592,18 @@ evin_doubletap_emulate(const struct input_event *eve)
 
             /* We have a mouse click to process */
             skip_syn = false;
+            break;
+
+        case BTN_TOUCH:
+            /* Start/end of touch - if these are emitted by the touch
+             * driver, we must not expect to see SYN_MT_REPORT events
+             * on touch release. */
+            if( eve->value == 0 )
+                skip_syn = false;
+            break;
+
+        default:
+            break;
         }
         break;
 


### PR DESCRIPTION
If touch driver is using BTN_TOUCH for start/end of touch reporting,
sending also SYN_MT_REPORT events on end of touch is optional. However
mce is expecting to see either ABS_MT_TRACKING_ID=-1 or SYN_MT_REPORT
when touch release happens and this breaks double tap detection.

Do not expect SYN_MT_REPORT events if BTN_TOUCH with zero value is seen.