### PR TITLE
Remove SoftOff mode

### DIFF
--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1344,12 +1344,6 @@ static const setting_t gconf_defaults[] =
     .def  = "true",
   },
   {
-    // MCE_LED_PATTERN_DEVICE_SOFT_OFF @ mce.h
-    .key  = "/system/osso/dsm/leds/PatternDeviceSoftOff",
-    .type = "b",
-    .def  = "true",
-  },
-  {
     // MCE_LED_PATTERN_POWER_OFF @ mce.h
     .key  = "/system/osso/dsm/leds/PatternPowerOff",
     .type = "b",

--- a/inifiles/hybris-led.ini
+++ b/inifiles/hybris-led.ini
@@ -26,9 +26,6 @@
 PatternDeviceOn=254;0;0;0;0;0000ff
 # 0000ff = blue
 
-PatternDeviceSoftOff=253;0;0;0;0;00ffff
-# 00ffff=cyan
-
 PatternDisplayDimmed=252;7;0;0;0;001f1f
 # 001f1f=low intensity cyan
 

--- a/inifiles/legacy.ini
+++ b/inifiles/legacy.ini
@@ -31,7 +31,6 @@ CameraPopoutUnlock=1
 #      (0 for continuous light; ONLY when the charger is connected!)
 # Intensity in steps from 0 (off) to 15 (full intensity)
 PatternDeviceOn=254;0;0;75;5000;10
-PatternDeviceSoftOff=253;0;0;100;10000;5
 PatternPowerOn=9;3;0;2000;1000;15
 PatternPowerOff=10;3;0;2000;1000;15
 PatternCommunication=30;1;0;250;2000;15
@@ -91,7 +90,6 @@ PatternExample=42;1;30;500;1500;10
 # e100 -- Wait for green trigger
 # e200 -- Wait for blue trigger
 PatternDeviceOn=254;0;0;4000205f20df7f007f007f007f000000;4000205f20df7f007f007f007f000000;4000205f20df7f007f007f007f000000
-PatternDeviceSoftOff=253;0;0;4000203f20bf7f007f007f007f007f000000;4000203f20bf7f007f007f007f007f000000;0000
 PatternPowerOn=9;3;0;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000
 PatternPowerOff=10;3;0;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000
 PatternCommunication=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
@@ -148,7 +146,6 @@ PatternExample=42;1;30;4000167f167f17ff17ff0000;4000167f167f17ff17ff0000;0000
 # e100 -- Wait for green trigger
 # e200 -- Wait for blue trigger
 PatternDeviceOn=254;0;0;4000e100207e207ee00420fe20fee0047f007f007f007f000000;4000e0024a15e0804a95e0807f007f007f007f000000;0000
-PatternDeviceSoftOff=253;0;0;4000204f20cf7f007f007f007f007f000000;4000204f20cf7f007f007f007f007f000000;0000
 PatternPowerOn=9;3;0;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000;4000207f207f01ff01ffc000
 PatternPowerOff=10;3;0;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000;4000017f017f36ff36ff7f00c000
 PatternCommunication=30;1;0;0000;0000;40007f00017f017f050001ff01ff0000
@@ -213,7 +210,6 @@ PatternExample=42;1;30;4000167f167f17ff17ff0000;4000167f167f17ff17ff0000;0000
 # e100 -- Wait for engine 2 trigger
 # e200 -- Wait for engine 3 trigger <used by key backlight!>
 PatternDeviceOn=254;0;0;rgb;9d804000422043207f100000;9d800000
-PatternDeviceSoftOff=253;0;0;rg;9d804000423f433f7f100000;9d800000
 PatternPowerOn=9;3;0;rgb;9d80400042ff02ffc000;9d800000
 PatternPowerOff=10;3;0;rgb;9d80400001ff43ff7f007f00c000;9d800000
 PatternCommunication=30;1;0;b;9d80400002ff03ff02ff03ff71080000;9d800000
@@ -262,9 +258,6 @@ PatternExample=42;1;30;rg;9d80400044ff45ff0000;9d800000
 #
 #         Use 0 steps to create pauses
 # c000 -- End pattern execution
-
-# FIXME: sloooooow breathing
-PatternDeviceSoftOff=253;0;0;9d804000423f433f7f100000
 
 PatternPowerOn=9;3;0;9d80400012ff03ffc000
 PatternPowerOff=10;3;0;9d80400002ff1bffc000
@@ -324,9 +317,6 @@ PatternExample=42;1;30;9d80400044ff45ff0000
 #         Two consecutive increment/decrement sequences are needed
 #         to cover the entire range from 0-255
 # c000 -- End pattern execution
-
-# FIXME: sloooooow breathing
-PatternDeviceSoftOff=253;0;0;4000413f41bf5f900000
 
 PatternPowerOn=9;3;0;4000087f087f01ff01ffc000
 PatternPowerOff=10;3;0;4000017f017fc000

--- a/inifiles/mce.ini
+++ b/inifiles/mce.ini
@@ -18,15 +18,6 @@ ModulePath=/usr/lib/mce/modules
 # Note: the name should not include the "lib"-prefix
 Modules=radiostates;filter-brightness-als;display;keypad;led;battery-statefs;inactivity;alarm;callstate;audiorouting;proximity;powersavemode;cpu-keepalive;doubletap;packagekit;sensor-gestures;bluetooth;memnotify;usbmode
 
-[SoftPowerOff]
-
-# Charger connect policy
-#
-# Valid options:
-# wakeup - wake up from soft poweroff when a charger is connected
-# ignore - remain in soft poweroff when a charger is connected
-ChargerPolicyConnect=ignore
-
 [KeyPad]
 
 # Timeout before disabling keyboard backlight when unused
@@ -51,7 +42,7 @@ BacklightFadeOutTime=1000
 [LED]
 
 # A list of all pattern names that should be configured
-LEDPatternsRequired=PatternPowerOn;PatternPowerOff;PatternCommunication;PatternCommunicationAndBatteryFull;PatternBatteryCharging;PatternBatteryChargingFlat;PatternBatteryFull;PatternDeviceSoftOff
+LEDPatternsRequired=PatternPowerOn;PatternPowerOff;PatternCommunication;PatternCommunicationAndBatteryFull;PatternBatteryCharging;PatternBatteryChargingFlat;PatternBatteryFull;
 CombinationRules=CombinationCommunicationAndBatteryFull
 # A list of pattern names that should not be used even if configured
 LEDPatternsDisabled=

--- a/mce-dsme.h
+++ b/mce-dsme.h
@@ -32,38 +32,8 @@
  */
 #define TRANSITION_DELAY		-1
 
-/** Name of Powerkey configuration group */
-#define MCE_CONF_SOFTPOWEROFF_GROUP	"SoftPowerOff"
-
-/** Name of configuration key for charger connect policy in soft poweroff */
-#define MCE_CONF_SOFTPOWEROFF_CHARGER_POLICY_CONNECT "ChargerPolicyConnect"
-
-/**
- * Name of configuration value for the "wake on charger" policy
- * when in soft poweroff
- */
-#define SOFTOFF_CHARGER_CONNECT_WAKEUP_STR		"wakeup"
-
-/**
- * Name of configuration value for the "ignore charger" policy
- * when in soft poweroff
- */
-#define SOFTOFF_CHARGER_CONNECT_IGNORE_STR		"ignore"
-
-/** Soft poweroff charger connect policy */
-enum {
-	/** Stay in offline mode */
-	SOFTOFF_CHARGER_CONNECT_WAKEUP = 0,
-	/** Restore previous mode */
-	SOFTOFF_CHARGER_CONNECT_IGNORE = 1,
-	/** Default setting */
-	DEFAULT_SOFTOFF_CHARGER_CONNECT = SOFTOFF_CHARGER_CONNECT_IGNORE,
-};
-
 void mce_dsme_request_powerup(void);
 void mce_dsme_request_reboot(void);
-void mce_dsme_request_soft_poweron(void);
-void mce_dsme_request_soft_poweroff(void);
 void mce_dsme_request_normal_shutdown(void);
 
 /* When MCE is made modular, this will be handled differently */

--- a/mce.h
+++ b/mce.h
@@ -46,9 +46,6 @@
 /** LED pattern used to indicate that the device is on when idle */
 #define MCE_LED_PATTERN_DEVICE_ON		"PatternDeviceOn"
 
-/** LED pattern used when the device is in soft poweroff mode */
-#define MCE_LED_PATTERN_DEVICE_SOFT_OFF		"PatternDeviceSoftOff"
-
 /** LED pattern used when charging the battery */
 #define MCE_LED_PATTERN_BATTERY_CHARGING	"PatternBatteryCharging"
 
@@ -134,9 +131,6 @@ typedef gint submode_t;
 
 /** Event eater enabled */
 #define MCE_EVEATER_SUBMODE		(1 << 1)
-
-/** Device emulates soft poweroff */
-#define MCE_SOFTOFF_SUBMODE		(1 << 2)
 
 /** Bootup in progress */
 #define MCE_BOOTUP_SUBMODE		(1 << 3)

--- a/modetransition.c
+++ b/modetransition.c
@@ -43,7 +43,6 @@ static char *mce_submode_change(const submode_t prev, const submode_t curr)
 		{ MCE_INVALID_SUBMODE,          "INVALID"          },
 		{ MCE_TKLOCK_SUBMODE,           "TKLOCK"           },
 		{ MCE_EVEATER_SUBMODE,          "EVEATER"          },
-		{ MCE_SOFTOFF_SUBMODE,          "SOFTOFF"          },
 		{ MCE_BOOTUP_SUBMODE,           "BOOTUP"           },
 		{ MCE_TRANSITION_SUBMODE,       "TRANSITION"       },
 		{ MCE_AUTORELOCK_SUBMODE,       "AUTORELOCK"       },

--- a/tklock.c
+++ b/tklock.c
@@ -3358,14 +3358,6 @@ static void tklock_evctrl_rethink(void)
      * overrides
      * - - - - - - - - - - - - - - - - - - - */
 
-#if 0 // FIXME: should we pretend soft-off is still supported?
-    if( submode & MCE_SOFTOFF_SUBMODE ) {
-        enable_kp = false;
-        enable_ts = false;
-        enable_dt = false;
-    }
-#endif
-
 #if 0 // FIXME: malf is not really supported yet
     if( submode & MCE_MALF_SUBMODE ) {
         enable_kp = false;

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -2826,7 +2826,6 @@ static bool xmce_is_powerkey_action(const char *name)
                 "blank",
                 "tklock",
                 "devlock",
-                "softoff",
                 "shutdown",
                 "unblank",
                 "tkunlock",
@@ -4441,7 +4440,6 @@ static const mce_opt_t options[] =
                         "  tklock   - lock ui\n"
                         "  devlock  - lock device\n"
                         "  dbus1    - send dbus signal or make method call\n"
-                        "  softoff  - enter softoff mode (legacy, not supported)\n"
                         "  shutdown - power off device\n"
                         "  unblank  - turn display on\n"
                         "  tkunlock - unlock ui\n"


### PR DESCRIPTION
SoftOff mode is basically manual suspend to RAM for pre N900 era maemo
devices. The logic in MCE side does not work and also support needed by
it has beed dropped from DSME side ages ago.

Remove all remnants of SoftOff mode that still linger in mce code tree.