### PR TITLE
Add SW_LID to list of events MCE is interested in

### DIFF
--- a/event-input.c
+++ b/event-input.c
@@ -1253,6 +1253,7 @@ evin_evdevtype_from_info(evin_evdevinfo_t *info)
         SW_FRONT_PROXIMITY,
         SW_HEADPHONE_INSERT,
         SW_KEYPAD_SLIDE,
+        SW_LID,
         SW_LINEOUT_INSERT,
         SW_MICROPHONE_INSERT,
         SW_VIDEOOUT_INSERT,


### PR DESCRIPTION
SW_LID was accidentally left out from the list and this went unnoticed
until a device with input device node that emits only SW_LID events
came across: sony ericsson xperia pro (iyokan).

Add SW_LID to the list so that the events actually get processed and
not used only as generic user activity triggers.