### PR TITLE
Add setting for enabling/disabling orientation sensor use

### DIFF
--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1164,6 +1164,11 @@ static const setting_t gconf_defaults[] =
     .def  = CUSTOM_STRINGIFY(DEFAULT_DISPLAY_DIM_TIMEOUT_LIST),
   },
   {
+    .key  = MCE_GCONF_ORIENTATION_SENSOR_ENABLED,
+    .type = "b",
+    .def  = G_STRINGIFY(DEFAULT_ORIENTATION_SENSOR_ENABLED),
+  },
+  {
     // Hint for settings UI. Not used by MCE itself.
     .key  = "/system/osso/dsm/display/possible_display_blank_timeouts",
     .type = "ai",

--- a/modules/display.h
+++ b/modules/display.h
@@ -305,4 +305,10 @@ enum
 /** Default value for MCE_GCONF_DISPLAY_DIM_TIMEOUT_LIST setting */
 #define DEFAULT_DISPLAY_DIM_TIMEOUT_LIST	15,30,60,120,180
 
+/** Use Orientation sensor GConf setting */
+# define MCE_GCONF_ORIENTATION_SENSOR_ENABLED   MCE_GCONF_DISPLAY_PATH"/orientation_sensor_enabled"
+
+/** Default value for MCE_GCONF_ORIENTATION_SENSOR_ENABLED setting */
+#define DEFAULT_ORIENTATION_SENSOR_ENABLED      true
+
 #endif /* _DISPLAY_H_ */

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -2451,6 +2451,34 @@ static void xmce_get_lid_sensor_mode(void)
 }
 
 /* ------------------------------------------------------------------------- *
+ * orientation sensor
+ * ------------------------------------------------------------------------- */
+
+/* Set orientation_sensor use mode
+ *
+ * @param args string suitable for interpreting as enabled/disabled
+ */
+static bool xmce_set_orientation_sensor_mode(const char *args)
+{
+        debugf("%s(%s)\n", __FUNCTION__, args);
+        gboolean val = xmce_parse_enabled(args);
+        mcetool_gconf_set_bool(MCE_GCONF_ORIENTATION_SENSOR_ENABLED, val);
+        return true;
+}
+
+/** Get current orientation_sensor mode from mce and print it out
+ */
+static void xmce_get_orientation_sensor_mode(void)
+{
+        gboolean val = 0;
+        char txt[32] = "unknown";
+
+        if( mcetool_gconf_get_bool(MCE_GCONF_ORIENTATION_SENSOR_ENABLED, &val) )
+                snprintf(txt, sizeof txt, "%s", val ? "enabled" : "disabled");
+        printf("%-"PAD1"s %s\n", "Use orientation sensor mode:", txt);
+}
+
+/* ------------------------------------------------------------------------- *
  * ps
  * ------------------------------------------------------------------------- */
 
@@ -4194,6 +4222,7 @@ static bool xmce_get_status(const char *args)
         xmce_get_als_mode();
         xmce_get_als_input_filter();
         xmce_get_als_sample_time();
+        xmce_get_orientation_sensor_mode();
         xmce_get_ps_mode();
         xmce_get_ps_blocks_touch();
         xmce_get_lid_sensor_mode();
@@ -4879,6 +4908,13 @@ static const mce_opt_t options[] =
                 .with_arg    = xmce_set_lid_sensor_mode,
                 .values      = "enabled|disabled",
                         "set the lid sensor mode; valid modes are:\n"
+                        "'enabled' and 'disabled'\n"
+        },
+        {
+                .name        = "set-orientation-sensor-mode",
+                .with_arg    = xmce_set_orientation_sensor_mode,
+                .values      = "enabled|disabled",
+                        "set the orientation sensor mode; valid modes are:\n"
                         "'enabled' and 'disabled'\n"
         },
         {


### PR DESCRIPTION
If orientation sensor is available, mce uses it for generating user
activity (delay automatic display blanking) and detecting device flip
over gestures (snooze alarm, silence incoming call). Sometimes neither
feature is desired, but there is no way to disable use of orientation
sensor.

Add disable/enable setting for using orientation sensor.

By default the setting is enabled, but can be changed for example by
installing hw specific mce configuration files or from command line

  mcetool --set-orientation-sensor-mode=<enabled|disabled>

The setting persists over mce/device restarts.