### PR TITLE
Tweak backlight control path configuration

### DIFF
--- a/inifiles/backlight.ini
+++ b/inifiles/backlight.ini
@@ -1,0 +1,21 @@
+# Configuration file for MCE - display brightness control paths
+#
+# Normally MCE locates display backlight control files by probing
+# few standard places under sysfs. In case the control files are
+# in non-standard directories or probing produces false positive
+# hits, a hardware adaptation specific configuration file should
+# be used to define alternative sets of paths to check before
+# generic probing.
+
+[Display]
+
+# Semicolon separated list of directories that contain writable
+# "brightness" and readable "max_brightness" files.
+#BrightnessDirectory=/sys/devices/i2c-0/0-0036/leds/lm3533-lcd-bl
+
+# In case the control files do not follow the "brightness" and
+# "max_brightness" pattern, semicolon separated list of full paths
+# can be defined. Note that BrightnessPath and MaxBrightnessPath
+# lists must have equal number of entries.
+#BrightnessPath=/sys/path/to/brightness_file
+#MaxBrightnessPath=/sys/path/to/max_brightness_file

--- a/modules/display.h
+++ b/modules/display.h
@@ -21,6 +21,18 @@
 #ifndef _DISPLAY_H_
 #define _DISPLAY_H_
 
+/** Name of the display backlight configuration group */
+#define MCE_CONF_DISPLAY_GROUP                  "Display"
+
+/** List of backlight control directories to try */
+#define MCE_CONF_BACKLIGHT_DIRECTORY            "BrightnessDirectory"
+
+/** List of backlight control files to try */
+#define MCE_CONF_BACKLIGHT_PATH                 "BrightnessPath"
+
+/** List of max backlight control files to try */
+#define MCE_CONF_MAX_BACKLIGHT_PATH             "MaxBrightnessPath"
+
 /** Default timeout for the high brightness mode; in seconds */
 #define DEFAULT_HBM_TIMEOUT				1800	/* 30 min */
 


### PR DESCRIPTION
A way to explicitly define for backlight brightness control paths has
been implemented a long time ago. However it uses hard-coded key names
that do not follow the conventions used in the rest of the mce code base.

Fix configuration item naming and use constants instead of hard-coding.

Warn if number of possible brightness control files differs from the
number of possible maximum brightness files.

Add an example configuration ini-file.