### PR TITLE
Fix after boot blank delay handling

### DIFF
--- a/modules/display.h
+++ b/modules/display.h
@@ -257,8 +257,8 @@ typedef enum
 /** Default dim timeout, in seconds */
 #define DEFAULT_DIM_TIMEOUT			30	/* 30 seconds */
 
-/** Additional dim timeout during bootup, in seconds */
-#define BOOTUP_DIM_ADDITIONAL_TIMEOUT		120	/* 120 seconds */
+/** Minimum blanking delay after bootup, in seconds */
+#define AFTERBOOT_BLANKING_TIMEOUT		30
 
 /**
  * Blank prevent timeout, in seconds;


### PR DESCRIPTION
The legacy feature for delaying display blanking immediately after
bootup does not really work and is designed for booting to home view.

Fix triggering rules so that extra blanking delay starts when lipstick
starts up while bootup is not finished yet and ends if display turns off
for any reason.

Apply extra blanking delay regardless of whether ui boots up to home
or lockscreen.

Decouple extra blanking delay from inactivity tracking.

Shorten the extra delay from 2 minutes to 30 seconds.