### PR TITLE
Add settings for exceptional display on state durations

### DIFF
--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1616,6 +1616,66 @@ static const setting_t gconf_defaults[] =
     .def  = "0", // = disabled
   },
   {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_CALL_IN,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_CALL_IN),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_CALL_OUT,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_CALL_OUT),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_ALARM,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_ALARM),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_USB_CONNECT,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_USB_CONNECT),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_USB_DIALOG,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_USB_DIALOG),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_CHARGER,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_CHARGER),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_BATTERY,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_BATTERY),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_JACK_IN,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_JACK_IN),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_JACK_OUT,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_JACK_OUT),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_CAMERA,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_CAMERA),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_VOLUME,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_VOLUME),
+  },
+  {
+    .key  = MCE_GCONF_EXCEPTION_LENGTH_ACTIVITY,
+    .type = "i",
+    .def  = G_STRINGIFY(DEFAULT_EXCEPTION_LENGTH_ACTIVITY),
+  },
+  {
     .key  = NULL,
   }
 };

--- a/tklock.h
+++ b/tklock.h
@@ -139,6 +139,54 @@ enum
     LPMUI_TRIGGERING_HOVER_OVER  = 1<<1,
 };
 
+/** How long to keep display on after incoming call ends [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_CALL_IN      MCE_GCONF_LOCK_PATH"/exception_length_call_in"
+#define DEFAULT_EXCEPTION_LENGTH_CALL_IN        5000
+
+/** How long to keep display on after outgoing call ends [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_CALL_OUT     MCE_GCONF_LOCK_PATH"/exception_length_call_out"
+#define DEFAULT_EXCEPTION_LENGTH_CALL_OUT       2500
+
+/** How long to keep display on after alarm is handled [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_ALARM        MCE_GCONF_LOCK_PATH"/exception_length_alarm"
+#define DEFAULT_EXCEPTION_LENGTH_ALARM          2500
+
+/** How long to keep display on when usb cable is connected [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_USB_CONNECT  MCE_GCONF_LOCK_PATH"/exception_length_usb_connect"
+#define DEFAULT_EXCEPTION_LENGTH_USB_CONNECT    5000
+
+/** How long to keep display on when usb mode dialog is shown [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_USB_DIALOG   MCE_GCONF_LOCK_PATH"/exception_length_usb_dialog"
+#define DEFAULT_EXCEPTION_LENGTH_USB_DIALOG     10000
+
+/** How long to keep display on when charging starts [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_CHARGER      MCE_GCONF_LOCK_PATH"/exception_length_charger"
+#define DEFAULT_EXCEPTION_LENGTH_CHARGER        3000
+
+/** How long to keep display on after battery full [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_BATTERY      MCE_GCONF_LOCK_PATH"/exception_length_battery"
+#define DEFAULT_EXCEPTION_LENGTH_BATTERY        0
+
+/** How long to keep display on when audio jack is inserted [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_JACK_IN      MCE_GCONF_LOCK_PATH"/exception_length_jack_in"
+#define DEFAULT_EXCEPTION_LENGTH_JACK_IN        3000
+
+/** How long to keep display on when audio jack is removed [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_JACK_OUT     MCE_GCONF_LOCK_PATH"/exception_length_jack_out"
+#define DEFAULT_EXCEPTION_LENGTH_JACK_OUT       3000
+
+/** How long to keep display on when camera button is pressed [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_CAMERA       MCE_GCONF_LOCK_PATH"/exception_length_camera"
+#define DEFAULT_EXCEPTION_LENGTH_CAMERA         3000
+
+/** How long to keep display on when volume button is pressed [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_VOLUME       MCE_GCONF_LOCK_PATH"/exception_length_volume"
+#define DEFAULT_EXCEPTION_LENGTH_VOLUME         2000
+
+/** How long to extend display on when there is user activity [ms] */
+#define MCE_GCONF_EXCEPTION_LENGTH_ACTIVITY     MCE_GCONF_LOCK_PATH"/exception_length_activity"
+#define DEFAULT_EXCEPTION_LENGTH_ACTIVITY       2000
+
 /** Name of D-Bus callback to provide to Touchscreen/Keypad Lock SystemUI */
 #define MCE_TKLOCK_CB_REQ		"tklock_callback"
 

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -2423,6 +2423,147 @@ static void xmce_get_adaptive_dimming_time(void)
 }
 
 /* ------------------------------------------------------------------------- *
+ * exception lengths
+ * ------------------------------------------------------------------------- */
+
+static bool xmce_set_exception_length_call_in(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_CALL_IN, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_call_out(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_CALL_OUT, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_alarm(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_ALARM, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_usb_connect(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_USB_CONNECT, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_usb_dialog(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_USB_DIALOG, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_charger(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_CHARGER, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_battery(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_BATTERY, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_jack_in(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_JACK_IN, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_jack_out(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_JACK_OUT, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_camera(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_CAMERA, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_volume(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_VOLUME, val);
+        return true;
+}
+
+static bool xmce_set_exception_length_activity(const char *args)
+{
+        int val = xmce_parse_integer(args);
+        mcetool_gconf_set_int(MCE_GCONF_EXCEPTION_LENGTH_ACTIVITY, val);
+        return true;
+}
+
+static void xmce_get_exception_length(const char *tag, const char *key)
+{
+        gint val = 0;
+        char txt[32];
+
+        if( !mcetool_gconf_get_int(key, &val) )
+                strcpy(txt, "unknown");
+        else if( val <= 0 )
+                strcpy(txt, "disabled");
+        else
+                snprintf(txt, sizeof txt, "%d ms", (int)val);
+        printf("%-"PAD1"s %s\n", tag, txt);
+}
+
+static void xmce_get_exception_lengths(void)
+{
+        xmce_get_exception_length("Display on after incoming call",
+                                  MCE_GCONF_EXCEPTION_LENGTH_CALL_IN);
+
+        xmce_get_exception_length("Display on after outgoing call",
+                                  MCE_GCONF_EXCEPTION_LENGTH_CALL_OUT);
+
+        xmce_get_exception_length("Display on after alarm",
+                                  MCE_GCONF_EXCEPTION_LENGTH_ALARM);
+
+        xmce_get_exception_length("Display on at usb connect",
+                                  MCE_GCONF_EXCEPTION_LENGTH_USB_CONNECT);
+
+        xmce_get_exception_length("Display on at usb mode query",
+                                  MCE_GCONF_EXCEPTION_LENGTH_USB_DIALOG);
+
+        xmce_get_exception_length("Display on at charging start",
+                                  MCE_GCONF_EXCEPTION_LENGTH_CHARGER);
+
+        xmce_get_exception_length("Display on at battery full",
+                                  MCE_GCONF_EXCEPTION_LENGTH_BATTERY);
+
+        xmce_get_exception_length("Display on at jack insert",
+                                  MCE_GCONF_EXCEPTION_LENGTH_JACK_IN);
+
+        xmce_get_exception_length("Display on at jack remove",
+                                  MCE_GCONF_EXCEPTION_LENGTH_JACK_OUT);
+
+        xmce_get_exception_length("Display on at camera button",
+                                  MCE_GCONF_EXCEPTION_LENGTH_CAMERA);
+
+        xmce_get_exception_length("Display on at volume button",
+                                  MCE_GCONF_EXCEPTION_LENGTH_VOLUME);
+
+        xmce_get_exception_length("Display on activity extension",
+                                  MCE_GCONF_EXCEPTION_LENGTH_ACTIVITY);
+}
+
+/* ------------------------------------------------------------------------- *
  * lid_sensor
  * ------------------------------------------------------------------------- */
 
@@ -4236,6 +4377,7 @@ static bool xmce_get_status(const char *args)
         xmce_get_tklock_blank();
         xmce_get_lipstick_core_delay();
         xmce_get_touch_unblock_delay();
+        xmce_get_exception_lengths();
 
         get_led_breathing_enabled();
         get_led_breathing_limit();
@@ -5161,6 +5303,92 @@ static const mce_opt_t options[] =
                 .values      = "page_count",
                 .usage       =
                         "set critical limit for active memory pages; zero=disabled\n"
+        },
+        {
+                .name        = "set-exception-length-call-in",
+                .with_arg    = xmce_set_exception_length_call_in,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on after incoming call"
+        },
+        {
+                .name        = "set-exception-length-call-out",
+                .with_arg    = xmce_set_exception_length_call_out,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on after outgoing call"
+        },
+        {
+                .name        = "set-exception-length-alarm",
+                .with_arg    = xmce_set_exception_length_alarm,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on after alarm"
+        },
+        {
+                .name        = "set-exception-length-usb-connect",
+                .with_arg    = xmce_set_exception_length_usb_connect,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on at usb connect"
+        },
+        {
+                .name        = "set-exception-length-usb-dialog",
+                .with_arg    = xmce_set_exception_length_usb_dialog,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on at usb mode query"
+        },
+        {
+                .name        = "set-exception-length-charger",
+                .with_arg    = xmce_set_exception_length_charger,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on at charging start"
+        },
+        {
+                .name        = "set-exception-length-battery",
+                .with_arg    = xmce_set_exception_length_battery,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on at battery full"
+        },
+        {
+                .name        = "set-exception-length-jack-in",
+                .with_arg    = xmce_set_exception_length_jack_in,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on at jack insert"
+        },
+        {
+                .name        = "set-exception-length-jack-out",
+                .with_arg    = xmce_set_exception_length_jack_out,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on at jack remove"
+        },
+        {
+                .name        = "set-exception-length-camera",
+                .with_arg    = xmce_set_exception_length_camera,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on at camera button\n"
+                        "\n"
+                        "Note: this is unverified legacy feature.\n"
+        },
+        {
+                .name        = "set-exception-length-volume",
+                .with_arg    = xmce_set_exception_length_volume,
+                .values      = "msec",
+                .usage       =
+                        "how long to keep display on at volume button"
+        },
+        {
+                .name        = "set-exception-length-activity",
+                .with_arg    = xmce_set_exception_length_activity,
+                .values      = "msec",
+                .usage       =
+                        "how much user activity extends display on"
         },
         {
                 .name        = "reset-settings",


### PR DESCRIPTION
Certain triggers like incoming call, alarm, usb connect, volume key
press, etc can cause the display to be turned on briefly. Many users
wish to tweak display on time following some triggers, but the durations
are hard coded.

Replace all hard coded durations with settings that can be changed
at run-time.

Allow disabling of individual triggers by setting zero duration.

Add mcetool options for changing the settings and showing the current
values.