### PR TITLE
Block user interaction when shutdown/reboot starts

### DIFF
--- a/datapipe.c
+++ b/datapipe.c
@@ -178,6 +178,9 @@ datapipe_struct packagekit_locked_pipe;
 /** Update mode active status; read only */
 datapipe_struct update_mode_pipe;
 
+/** Shutting down; read only */
+datapipe_struct shutting_down_pipe;
+
 /** Device Lock state; read only */
 datapipe_struct device_lock_state_pipe;
 
@@ -891,6 +894,8 @@ void mce_datapipe_init(void)
 		       0, GINT_TO_POINTER(FALSE));
 	setup_datapipe(&update_mode_pipe, READ_ONLY, DONT_FREE_CACHE,
 		       0, GINT_TO_POINTER(FALSE));
+	setup_datapipe(&shutting_down_pipe, READ_ONLY, DONT_FREE_CACHE,
+		       0, GINT_TO_POINTER(FALSE));
 	setup_datapipe(&device_lock_state_pipe, READ_ONLY, DONT_FREE_CACHE,
 		       0, GINT_TO_POINTER(DEVICE_LOCK_UNDEFINED));
 	setup_datapipe(&touch_grab_wanted_pipe, READ_WRITE, DONT_FREE_CACHE,
@@ -959,6 +964,7 @@ void mce_datapipe_quit(void)
 	free_datapipe(&dsme_available_pipe);
 	free_datapipe(&packagekit_locked_pipe);
 	free_datapipe(&update_mode_pipe);
+	free_datapipe(&shutting_down_pipe);
 	free_datapipe(&device_lock_state_pipe);
 	free_datapipe(&touch_grab_active_pipe);
 	free_datapipe(&touch_grab_wanted_pipe);

--- a/datapipe.h
+++ b/datapipe.h
@@ -138,6 +138,7 @@ extern datapipe_struct usbmoded_available_pipe;
 extern datapipe_struct dsme_available_pipe;
 extern datapipe_struct packagekit_locked_pipe;
 extern datapipe_struct update_mode_pipe;
+extern datapipe_struct shutting_down_pipe;
 extern datapipe_struct device_lock_state_pipe;
 extern datapipe_struct touch_grab_wanted_pipe;
 extern datapipe_struct touch_grab_active_pipe;

--- a/modules/display.c
+++ b/modules/display.c
@@ -754,6 +754,10 @@ static void mdy_shutdown_set_state(bool in_progress)
         mce_log(LL_DEVEL, "Shutdown canceled");
     }
 
+    execute_datapipe(&shutting_down_pipe,
+                     GINT_TO_POINTER(mdy_shutdown_started_flag),
+                     USE_INDATA, CACHE_INDATA);
+
     /* Framebuffer must be kept open during shutdown */
     mdy_fbdev_rethink();
 


### PR DESCRIPTION
It is possible to trigger ui actions via touchscreen and volume keys
after shutdown/reboot has already started.

Take shutdown state into account in input policy and block touch
screen and volume keys during shutdown/reboot.

Tune rules for touch-is-blocked debug led pattern so that it will get
triggered also if blocking starts at display on state.