### PR TITLE
Allow volume keys to be used in the lock screen

### DIFF
--- a/tklock.c
+++ b/tklock.c
@@ -3403,11 +3403,6 @@ static void tklock_evctrl_rethink(void)
         break;
     }
 
-    /* tklock must be off */
-    if( submode & MCE_TKLOCK_SUBMODE ) {
-        enable_kp = false;
-    }
-
     /* If the cover is closed, don't bother */
 #if 0 /* TODO: Lid cover state is tracked, but volume keys should be
        *       disabled only if they are unlikely to be useful i.e.


### PR DESCRIPTION
MCE has volume key policy that blocks ui from seeing volume keys unless
certain criteria is met.

Relax the rules so that volume keys are not blocked when the display
is on and lockscreen is shown. UI side decides how to act on them.