### PR TITLE
Start dim timer also when blanking pause period ends due to timeout

### DIFF
--- a/modules/display.c
+++ b/modules/display.c
@@ -3674,14 +3674,18 @@ EXIT:
 /** Remove all clients, stop blanking pause */
 static void mdy_blanking_remove_pause_clients(void)
 {
+    /* If there are clients to remove or blanking pause timer to stop,
+     * we need to re-evaluate need for dimming timer before returning */
+    bool rethink = (mdy_blanking_pause_clients || mdy_blanking_is_paused());
+
     /* Remove all name monitors for the blanking pause requester */
     mce_dbus_owner_monitor_remove_all(&mdy_blanking_pause_clients);
 
-    if( mdy_blanking_is_paused() ) {
-        /* Stop blank prevent timer */
-        mdy_blanking_stop_pause_period();
+    /* Stop blank prevent timer */
+    mdy_blanking_stop_pause_period();
+
+    if( rethink )
         mdy_blanking_rethink_timers(true);
-    }
 }
 
 /** Handle blanking pause clients dropping from dbus


### PR DESCRIPTION
Blanking pause client removal starts dimming timer only if blanking
pause timer is still active. If clients just stop renewing the blanking
pause period instead of explicitly stopping it, the timer triggers and
gets deactivated. This causes the display stay on until user activity
causes dim timer reprogramming.

If there were active clients, reprogram the dim timeout even if the
blanking pause timer is no longer active.