### PR TITLE
Allow keyboard input device to get slider state from another input device

### DIFF
--- a/inifiles/evdev.ini
+++ b/inifiles/evdev.ini
@@ -44,3 +44,12 @@
 #SW_LINEOUT_INSERT=SW_MAX
 #SW_MICROPHONE_INSERT=SW_MAX
 #SW_VIDEOOUT_INSERT=SW_MAX
+
+[SW_KEYPAD_SLIDE]
+
+# For example "iyokan" devices have keypress events coming from
+# one input device and keypad slide status from another. To make
+# sliding keyboard availability evaluation work, we need to tell
+# mce to get slider status for "pm8xxx-keypad" from "gpio-slider"
+# input device.
+#pm8xxx-keypad=gpio-slider


### PR DESCRIPTION
There is an assumption in mce that slidable keyboards emit SW_KEYPAD_SLIDE
events from the same input device that is emitting the actual key press
events. However for example iyokan devices emits key presses from
"pm8xxx-keypad" device and slide status as SW_LID event from "gpio-slider".
While is already possible to use configuration files map SW_LID to the
SW_KEYPAD_SLIDE event expected by mce, the keyboard availability logic
does not work because it comes from different input device node.

Make it possible to link keyboard input device to another input device
that emits (optionally translated) SW_KEYPAD_SLIDE events.

When evaluating sliding keyboard status, fetch the slider state from
the device specified in the configuration.

Add keyboard to slider state linking entry to example evdev input
configuration file.