### PR TITLE
Allow fine tuning ALS usage via mce settings

### DIFF
--- a/.depend
+++ b/.depend
@@ -595,6 +595,7 @@ modules/filter-brightness-als.o:\
 	mce-log.h\
 	mce-sensorfw.h\
 	mce.h\
+	tklock.h\
 	modules/display.h\
 	modules/filter-brightness-als.h\
 
@@ -609,6 +610,7 @@ modules/filter-brightness-als.pic.o:\
 	mce-log.h\
 	mce-sensorfw.h\
 	mce.h\
+	tklock.h\
 	modules/display.h\
 	modules/filter-brightness-als.h\
 

--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1089,20 +1089,22 @@ static const setting_t gconf_defaults[] =
     .def  = "10,20,30,40,50",
   },
   {
-    // MCE_GCONF_DISPLAY_ALS_ENABLED @ modules/display.h
-    .key  = "/system/osso/dsm/display/als_enabled",
+    .key  = MCE_GCONF_DISPLAY_ALS_ENABLED,
     .type = "b",
-    .def  = "true",
+    .def  = G_STRINGIFY(ALS_ENABLED_DEFAULT),
   },
   {
-    // MCE_GCONF_DISPLAY_ALS_INPUT_FILTER @ modules/display.h
-    .key  = "/system/osso/dsm/display/als_input_filter",
+    .key  = MCE_GCONF_DISPLAY_ALS_AUTOBRIGHTNESS,
+    .type = "b",
+    .def  = G_STRINGIFY(ALS_AUTOBRIGHTNESS_DEFAULT),
+  },
+  {
+    .key  = MCE_GCONF_DISPLAY_ALS_INPUT_FILTER,
     .type = "s",
     .def  = ALS_INPUT_FILTER_DEFAULT,
   },
   {
-    // MCE_GCONF_DISPLAY_ALS_SAMPLE_TIME @ modules/display.h
-    .key  = "/system/osso/dsm/display/als_sample_time",
+    .key  = MCE_GCONF_DISPLAY_ALS_SAMPLE_TIME,
     .type = "i",
     .def  = G_STRINGIFY(ALS_SAMPLE_TIME_DEFAULT),
   },
@@ -1223,6 +1225,11 @@ static const setting_t gconf_defaults[] =
     .key  = MCE_GCONF_LID_SENSOR_ENABLED,
     .type = "b",
     .def  = G_STRINGIFY(DEFAULT_LID_SENSOR_ENABLED),
+  },
+  {
+    .key  = MCE_GCONF_FILTER_LID_WITH_ALS,
+    .type = "b",
+    .def  = G_STRINGIFY(DEFAULT_FILTER_LID_WITH_ALS),
   },
   {
     .key  = MCE_GCONF_AUTOLOCK_DELAY,

--- a/mce-sensorfw.c
+++ b/mce-sensorfw.c
@@ -3113,7 +3113,7 @@ static guint als_evdev_id = 0;
 static void (*sfw_notify_ps_cb)(bool covered) = 0;
 
 /** Ambient light change callback used for notifying upper level logic */
-static void (*sfw_notify_als_cb)(unsigned lux) = 0;
+static void (*sfw_notify_als_cb)(int lux) = 0;
 
 /** Orientation change callback used for notifying upper level logic */
 static void (*sfw_notify_orient_cb)(int state) = 0;
@@ -3406,7 +3406,7 @@ mce_sensorfw_resume(void)
  * @param cb function to call when ALS events are received
  */
 void
-mce_sensorfw_als_set_notify(void (*cb)(unsigned lux))
+mce_sensorfw_als_set_notify(void (*cb)(int lux))
 {
     if( (sfw_notify_als_cb = cb) )
         sfw_notify_als(NOTIFY_REPEAT, 0);

--- a/mce-sensorfw.h
+++ b/mce-sensorfw.h
@@ -16,7 +16,7 @@ void mce_sensorfw_suspend(void);
 void mce_sensorfw_resume(void);
 
 void mce_sensorfw_als_attach(int fd);
-void mce_sensorfw_als_set_notify(void (*cb)(unsigned lux));
+void mce_sensorfw_als_set_notify(void (*cb)(int lux));
 void mce_sensorfw_als_enable(void);
 void mce_sensorfw_als_disable(void);
 

--- a/modules/display.h
+++ b/modules/display.h
@@ -111,14 +111,29 @@
 /** Path to the GConf settings for the display */
 #define MCE_GCONF_DISPLAY_PATH			"/system/osso/dsm/display"
 
-/** Path to the ALS enabled GConf setting */
+/** ALS enabled setting */
 #define MCE_GCONF_DISPLAY_ALS_ENABLED                   MCE_GCONF_DISPLAY_PATH "/als_enabled"
 
-/** ALS input filter GConf setting */
+/** Default value for MCE_GCONF_DISPLAY_ALS_ENABLED */
+#define ALS_ENABLED_DEFAULT                             true
+
+/** ALS constrols brightness setting */
+#define MCE_GCONF_DISPLAY_ALS_AUTOBRIGHTNESS            MCE_GCONF_DISPLAY_PATH "/als_autobrightness"
+
+/** Default value for MCE_GCONF_DISPLAY_ALS_AUTOBRIGHTNESS settings */
+#define ALS_AUTOBRIGHTNESS_DEFAULT                      true
+
+/** ALS input filter setting */
 #define MCE_GCONF_DISPLAY_ALS_INPUT_FILTER              MCE_GCONF_DISPLAY_PATH "/als_input_filter"
+
+/** Default value for MCE_GCONF_DISPLAY_ALS_INPUT_FILTER */
+#define ALS_INPUT_FILTER_DEFAULT                        "median"
 
 /** ALS sample time GConf setting */
 #define MCE_GCONF_DISPLAY_ALS_SAMPLE_TIME               MCE_GCONF_DISPLAY_PATH "/als_sample_time"
+#define ALS_SAMPLE_TIME_DEFAULT                         125
+#define ALS_SAMPLE_TIME_MIN                             50
+#define ALS_SAMPLE_TIME_MAX                             1000
 
 /** Path to the color profile GConf setting */
 #define MCE_GCONF_DISPLAY_COLOR_PROFILE                 MCE_GCONF_DISPLAY_PATH "/color_profile"

--- a/modules/filter-brightness-als.h
+++ b/modules/filter-brightness-als.h
@@ -34,18 +34,6 @@
 /** Name of the hardcoded color profile */
 #define COLOR_PROFILE_ID_HARDCODED	"hardcoded"
 
-/** Default value for als enabled settings */
-#define ALS_ENABLED_DEFAULT		TRUE
-
-/** Default value for als input filter settings */
-#define ALS_INPUT_FILTER_DEFAULT	"median"
-
-/** Default value for als sample time settings */
-#define ALS_SAMPLE_TIME_DEFAULT		125
-
-#define ALS_SAMPLE_TIME_MIN		50
-#define ALS_SAMPLE_TIME_MAX		1000
-
 /** ALS profiles */
 typedef enum {
 	ALS_PROFILE_COUNT  = 21,		/**< Number of profiles */

--- a/tklock.h
+++ b/tklock.h
@@ -120,6 +120,10 @@ typedef enum
 /** Default value for MCE_GCONF_PROXIMITY_PS_ENABLED_PATH */
 # define DEFAULT_LID_SENSOR_ENABLED             true
 
+/** Whether to use ALS data for LID sensor filtering */
+#define MCE_GCONF_FILTER_LID_WITH_ALS           MCE_GCONF_LOCK_PATH"/filter_lid_with_als"
+#define DEFAULT_FILTER_LID_WITH_ALS             true
+
 /** Autolock delay GConf setting [ms]*/
 # define MCE_GCONF_AUTOLOCK_DELAY		MCE_GCONF_LOCK_PATH "/autolock_delay"
 # define DEFAULT_AUTOLOCK_DELAY                 30000

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -2671,6 +2671,30 @@ static void xmce_get_exception_lengths(void)
  * lid_sensor
  * ------------------------------------------------------------------------- */
 
+/* Set filter lid with als mode
+ *
+ * @param args string suitable for interpreting as enabled/disabled
+ */
+static bool xmce_set_filter_lid_with_als(const char *args)
+{
+        debugf("%s(%s)\n", __FUNCTION__, args);
+        gboolean val = xmce_parse_enabled(args);
+        mcetool_gconf_set_bool(MCE_GCONF_FILTER_LID_WITH_ALS, val);
+        return true;
+}
+
+/* Get current filter lid with als mode from mce and print it out
+ */
+static void xmce_get_filter_lid_with_als(void)
+{
+        gboolean val = 0;
+        char txt[32] = "unknown";
+
+        if( mcetool_gconf_get_bool(MCE_GCONF_FILTER_LID_WITH_ALS, &val) )
+                snprintf(txt, sizeof txt, "%s", val ? "enabled" : "disabled");
+        printf("%-"PAD1"s %s\n", "Filter lid with als:", txt);
+}
+
 /* Set lid_sensor use mode
  *
  * @param args string suitable for interpreting as enabled/disabled
@@ -2777,6 +2801,30 @@ static void xmce_get_ps_blocks_touch(void)
 /* ------------------------------------------------------------------------- *
  * als
  * ------------------------------------------------------------------------- */
+
+/* Set als autobrightness mode
+ *
+ * @param args string suitable for interpreting as enabled/disabled
+ */
+static bool xmce_set_als_autobrightness(const char *args)
+{
+        debugf("%s(%s)\n", __FUNCTION__, args);
+        gboolean val = xmce_parse_enabled(args);
+        mcetool_gconf_set_bool(MCE_GCONF_DISPLAY_ALS_AUTOBRIGHTNESS, val);
+        return true;
+}
+
+/** Get current als autobrightness from mce and print it out
+ */
+static void xmce_get_als_autobrightness(void)
+{
+        gboolean val = 0;
+        char txt[32] = "unknown";
+
+        if( mcetool_gconf_get_bool(MCE_GCONF_DISPLAY_ALS_AUTOBRIGHTNESS, &val) )
+                snprintf(txt, sizeof txt, "%s", val ? "enabled" : "disabled");
+        printf("%-"PAD1"s %s\n", "Use als autobrightness:", txt);
+}
 
 /* Set als use mode
  *
@@ -4465,12 +4513,14 @@ static bool xmce_get_status(const char *args)
         xmce_get_low_power_mode();
         xmce_get_lpmui_triggering();
         xmce_get_als_mode();
+        xmce_get_als_autobrightness();
         xmce_get_als_input_filter();
         xmce_get_als_sample_time();
         xmce_get_orientation_sensor_mode();
         xmce_get_ps_mode();
         xmce_get_ps_blocks_touch();
         xmce_get_lid_sensor_mode();
+        xmce_get_filter_lid_with_als();
         xmce_get_dim_timeouts();
         xmce_get_brightness_fade();
         xmce_get_suspend_policy();
@@ -5096,8 +5146,23 @@ static const mce_opt_t options[] =
                 .with_arg    = xmce_set_als_mode,
                 .values      = "enabled|disabled",
                 .usage       =
-                        "set the als mode; valid modes are:\n"
+                        "set the als master mode; valid modes are:\n"
                         "'enabled' and 'disabled'\n"
+                        "\n"
+                        "If disabled, mce will never power up the ambient light\n"
+                        "sensor. If enabled, ALS is used depending on device.\n"
+                        "state and feature specific settings.\n"
+        },
+        {
+                .name        = "set-als-autobrightness",
+                .with_arg    = xmce_set_als_autobrightness,
+                .values      = "enabled|disabled",
+                .usage       =
+                        "use the als for automatic brightness tuning; valid modes are:\n"
+                        "'enabled' and 'disabled'\n"
+                        "\n"
+                        "When enabled, affects display, notification led and keypad\n"
+                        "backlight brightness.\n"
         },
         {
                 .name        = "set-als-input-filter",
@@ -5137,6 +5202,16 @@ static const mce_opt_t options[] =
                 .values      = "enabled|disabled",
                         "set the lid sensor mode; valid modes are:\n"
                         "'enabled' and 'disabled'\n"
+        },
+        {
+                .name        = "set-filter-lid-with-als",
+                .with_arg    = xmce_set_filter_lid_with_als,
+                .values      = "enabled|disabled",
+                        "set filter lid close events with als mode; valid modes are:\n"
+                        "'enabled' and 'disabled'\n"
+                        "\n"
+                        "When enabled, lid closed events are acted on only if they\n"
+                        "happen in close proximity to light level drop.\n"
         },
         {
                 .name        = "set-orientation-sensor-mode",


### PR DESCRIPTION
MCE has one setting that dictates whether ambient light sensor is used
or not. This was ok as long as ALS was used only for display brightness
tuning, but now that there are other reasons for using ALS functionality
of those too depend on whether automatic brightness tuning is in use or
not.

Leave the existing setting in place, use it as ALS master toggle and
add separate settings for:
- Use ALS automatic display brightness tuning
- Use ALS for filtering false positive lid closed events

If the master toggle is set to disabled, ALS is not used by mce.

If the master toggle is set to enabled, ALS is powered up/down depending
on feature specific settings and device state.

Refactor ALS data processing so that:
- callback for passing lux value from sensorfw uses int, not unsigned int
- als power up depends on all three settings
- variables holding cached lux values are given more descriptive names
- all auto brightness filters use similar logic for testing whether the
  feature is enabled & als data is available
- move all constants related to display settings to display.h

ALS data is used for filtering out potential false positive lid close
events only if the relevant settings are enabled.

Options for mcetool:
  --set-als-mode=<enabled|disabled>
  Now works as use als master toggle.

  --set-als-autobrightness=<enabled|disabled>
  Can be used to disable automatic brightness tuning even if using ALS
  is otherwise enabled.

  --set-filter-lid-with-als=<enabled|disabled>
  Can be used to disable lid close filtering even if using ALS is
  otherwise enabled.