### PR TITLE
Use hbtimer for led pattern auto-deactivation

### DIFF
--- a/.depend
+++ b/.depend
@@ -677,6 +677,7 @@ modules/led.o:\
 	mce-dbus.h\
 	mce-gconf.h\
 	mce-hal.h\
+	mce-hbtimer.h\
 	mce-hybris.h\
 	mce-io.h\
 	mce-lib.h\
@@ -693,6 +694,7 @@ modules/led.pic.o:\
 	mce-dbus.h\
 	mce-gconf.h\
 	mce-hal.h\
+	mce-hbtimer.h\
 	mce-hybris.h\
 	mce-io.h\
 	mce-lib.h\


### PR DESCRIPTION
It is possible to configure mce led patterns to automatically deactivate
after specified amount of seconds. However the logic uses normal user
space timers which makes the feature pretty much useless in devices
that use suspend type power management. Also a common timer is used
for controlling the timeout, which means the period gets restarted
if some higher priority pattern gets temporarily activated.

Use hbtimer for pattern deactivation so that the device will wake up from
suspend to deactivate the led.

Use separate timer for each pattern that is configured to use pattern
timeout. This makes it possible to handle overlapping pattern activations
with timeouts correctly - whether things actually work as expected depends
on the pattern activation side logic too.

Also the timers are not stopped if led feature is disabled. This makes
the auto deactivation work also if the feature is re-enabled later on.