### PR TITLE
Assume lid sensor is broken until closed to open transition is seen

### DIFF
--- a/event-input.c
+++ b/event-input.c
@@ -2065,7 +2065,8 @@ evin_iomon_keypress_cb(gpointer data, gsize bytes_read)
     /* Map event before processing */
     evin_event_mapper_translate_event(ev);
 
-    mce_log(LL_DEBUG, "type: %s, code: %s, value: %d",
+    mce_log((ev->type == EV_SW && ev->code == SW_LID) ? LL_DEVEL : LL_DEBUG,
+            "type: %s, code: %s, value: %d",
             evdev_get_event_type_name(ev->type),
             evdev_get_event_code_name(ev->type, ev->code),
             ev->value);
@@ -2444,6 +2445,8 @@ evin_iomon_switch_states_update_iter_cb(gpointer io_monitor, gpointer user_data)
     ecode = evin_event_mapper_rlookup_switch(SW_LID);
     if( test_bit(ecode, featurelist) ) {
         state = test_bit(ecode, statelist) ? COVER_CLOSED : COVER_OPEN;
+        mce_log(LL_DEVEL, "SW_LID initial state = %s",
+                cover_state_repr(state));
         execute_datapipe(&lid_cover_sensor_pipe, GINT_TO_POINTER(state),
                          USE_INDATA, CACHE_INDATA);
     }

--- a/tklock.c
+++ b/tklock.c
@@ -1764,15 +1764,15 @@ static void tklock_datapipe_lid_cover_sensor_cb(gconstpointer data)
     if( lid_cover_sensor_state == prev )
         goto EXIT;
 
-    if( lid_cover_sensor_state == COVER_OPEN ) {
-        /* We have seen the sensor flip to open position, so we can
-         * stop assuming it stays forever in the closed position */
+    if( prev == COVER_CLOSED &&  lid_cover_sensor_state == COVER_OPEN ) {
+        /* We have seen the sensor flip from closed to open position,
+         * so we can stop assuming it stays closed forever */
         execute_datapipe(&lid_sensor_is_working_pipe,
                          GINT_TO_POINTER(true),
                          USE_INDATA, CACHE_INDATA);
     }
 
-    mce_log(LL_DEBUG, "lid_cover_sensor_state = %s -> %s",
+    mce_log(LL_DEVEL, "lid_cover_sensor_state = %s -> %s",
             cover_state_repr(prev),
             cover_state_repr(lid_cover_sensor_state));
 
@@ -1798,7 +1798,7 @@ static void tklock_datapipe_lid_cover_policy_cb(gconstpointer data)
     if( lid_cover_policy_state == prev )
         goto EXIT;
 
-    mce_log(LL_DEBUG, "lid_cover_policy_state = %s -> %s",
+    mce_log(LL_DEVEL, "lid_cover_policy_state = %s -> %s",
             cover_state_repr(prev),
             cover_state_repr(lid_cover_policy_state));
 
@@ -2373,7 +2373,7 @@ static void tklock_lid_sensor_rethink(void)
     case COVER_OPEN:
         /* No action on initial undef -> open */
         if( action_prev == COVER_UNDEF ) {
-          mce_log(LL_DEVEL, "lid open - initial state ignored");
+            mce_log(LL_DEVEL, "lid open - initial state ignored");
             break;
         }
 


### PR DESCRIPTION
It is possible that sensor driver & broken sensor hw initially reports
lid is open and later switches permanently to closed position. This
breaks the broken sensor heuristics used by mce.

Instead of requiring just seeing the sensor in open position, the sensor
must report transition from closed to open state before it is assumed
to be working as expected.

Also elevate lid sensor related diagnostic logging so that they show
up by default in devel builds of mce.